### PR TITLE
Hotfix v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision History
 
-## 1.0.1 (unreleased)
+## 1.0.1 (2016/05/31)
 
 - Replaced calls to `git remote add origin` with `git remote set-url origin`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision History
 
+## 1.0.1 (unreleased)
+
+- Replaced calls to `git remote add origin` with `git remote set-url origin`.
+
 ## 1.0 (2016/05/22)
 
 - Initial stable release.

--- a/gitman/__init__.py
+++ b/gitman/__init__.py
@@ -3,7 +3,7 @@
 import sys
 
 __project__ = 'GitMan'
-__version__ = '1.0'
+__version__ = '1.0.1rc1'
 
 CLI = 'gitman'
 PLUGIN = 'deps'

--- a/gitman/__init__.py
+++ b/gitman/__init__.py
@@ -3,7 +3,7 @@
 import sys
 
 __project__ = 'GitMan'
-__version__ = '1.0.1rc1'
+__version__ = '1.0.1'
 
 CLI = 'gitman'
 PLUGIN = 'deps'

--- a/gitman/git.py
+++ b/gitman/git.py
@@ -32,8 +32,7 @@ def clone(repo, path, *, cache=None):
 
 def fetch(repo, rev=None):
     """Fetch the latest changes from the remote repository."""
-    git('remote', 'rm', 'origin', _show=False, _ignore=True)
-    git('remote', 'add', 'origin', repo)
+    git('remote', 'set-url', 'origin', repo)
     args = ['fetch', '--tags', '--force', '--prune', 'origin']
     if rev:
         if len(rev) == 40:

--- a/gitman/test/test_git.py
+++ b/gitman/test/test_git.py
@@ -10,7 +10,6 @@ from . import assert_calls
 
 @patch('gitman.git.call')
 class TestGit:
-
     """Tests for calls to Git."""
 
     @patch('os.path.isdir', Mock(return_value=False))
@@ -32,8 +31,7 @@ class TestGit:
         """Verify the commands to fetch from a Git repository."""
         git.fetch('mock.git')
         assert_calls(mock_call, [
-            "git remote rm origin",
-            "git remote add origin mock.git",
+            "git remote set-url origin mock.git",
             "git fetch --tags --force --prune origin",
         ])
 
@@ -41,8 +39,7 @@ class TestGit:
         """Verify the commands to fetch from a Git repository w/ rev."""
         git.fetch('mock.git', 'mock-rev')
         assert_calls(mock_call, [
-            "git remote rm origin",
-            "git remote add origin mock.git",
+            "git remote set-url origin mock.git",
             "git fetch --tags --force --prune origin mock-rev",
         ])
 
@@ -50,8 +47,7 @@ class TestGit:
         """Verify the commands to fetch from a Git repository w/ SHA."""
         git.fetch('mock.git', 'abcdef1234' * 4)
         assert_calls(mock_call, [
-            "git remote rm origin",
-            "git remote add origin mock.git",
+            "git remote set-url origin mock.git",
             "git fetch --tags --force --prune origin",
         ])
 
@@ -59,8 +55,7 @@ class TestGit:
         """Verify the commands to fetch from a Git repository w/ rev-parse."""
         git.fetch('mock.git', 'master@{2015-02-12 18:30:00}')
         assert_calls(mock_call, [
-            "git remote rm origin",
-            "git remote add origin mock.git",
+            "git remote set-url origin mock.git",
             "git fetch --tags --force --prune origin",
         ])
 


### PR DESCRIPTION
The old method seems to be broken in newer versions of Git:

```
$ git --version
git version 2.8.1
hub version 2.2.1

$ git remote rm origin
$ git remote add origin https://github.com/owner/repo
fatal: remote origin already exists.
```