### PR TITLE
WIP: Enable sparse checkouts for referenced repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.5 (unreleased)
 
 - Added `--keep-location` option on `uninstall` (@DavidWatkins).
+- Added feature to enable sparse checkouts. See the docs for further information. (@xenji)
+
 
 ## 1.4 (2017/03/21)
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ sources:
   rev: master
   scripts:
   - chmod a+x truffleHog.py
+- name: fontawesome
+  repo: https://github.com/FortAwesome/Font-Awesome
+  rev: master
+  sparse_paths:
+  - fonts
 ```
 
 Ignore the dependency storage location:
@@ -83,9 +88,10 @@ which will essentially:
 1. Create a working tree at `<root>`/`<location>`/`<name>`
 2. Fetch from `repo` and checkout the specified `rev`
 3. Symbolically link each `<location>`/`<name>` from `<root>`/`<link>` (if specified)
-4. Repeat for all nested working trees containing a config file
-5. Record the actual commit SHAs that were checked out (with `--lock` option)
-6. Run optional post-install scripts for each dependency
+4. Materialize only the selected paths from `sparse_paths`, if present in the config file
+5. Repeat for all nested working trees containing a config file
+6. Record the actual commit SHAs that were checked out (with `--lock` option)
+7. Run optional post-install scripts for each dependency
 
 where `rev` can be:
 
@@ -93,6 +99,11 @@ where `rev` can be:
 * a tag: `v1.0`
 * a branch: `master`
 * a `rev-parse` date: `'develop@{2015-06-18 10:30:59}'`
+
+`sparse_paths` can be a list of directories to check out. Using `sparse_paths` will use git's sparse checkout
+feature to just materialize the selected paths in the working tree. As this is a
+[git feature](https://git-scm.com/docs/git-read-tree#_sparse_checkout), all syntax options are available and passed
+unmodified to `$GIT_DIR/info/sparse-checkout`.
 
 ## Restoring Previous Versions
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ sources:
   - chmod a+x truffleHog.py
 - name: fontawesome
   repo: https://github.com/FortAwesome/Font-Awesome
-  rev: master
   sparse_paths:
-  - fonts
+  - fonts/*
+  rev: master
 ```
 
 Ignore the dependency storage location:
@@ -88,10 +88,9 @@ which will essentially:
 1. Create a working tree at `<root>`/`<location>`/`<name>`
 2. Fetch from `repo` and checkout the specified `rev`
 3. Symbolically link each `<location>`/`<name>` from `<root>`/`<link>` (if specified)
-4. Materialize only the selected paths from `sparse_paths`, if present in the config file
-5. Repeat for all nested working trees containing a config file
-6. Record the actual commit SHAs that were checked out (with `--lock` option)
-7. Run optional post-install scripts for each dependency
+4. Repeat for all nested working trees containing a config file
+5. Record the actual commit SHAs that were checked out (with `--lock` option)
+6. Run optional post-install scripts for each dependency
 
 where `rev` can be:
 
@@ -99,11 +98,6 @@ where `rev` can be:
 * a tag: `v1.0`
 * a branch: `master`
 * a `rev-parse` date: `'develop@{2015-06-18 10:30:59}'`
-
-`sparse_paths` can be a list of directories to check out. Using `sparse_paths` will use git's sparse checkout
-feature to just materialize the selected paths in the working tree. As this is a
-[git feature](https://git-scm.com/docs/git-read-tree#_sparse_checkout), all syntax options are available and passed
-unmodified to `$GIT_DIR/info/sparse-checkout`.
 
 ## Restoring Previous Versions
 

--- a/docs/use-cases/sparse-checkouts.md
+++ b/docs/use-cases/sparse-checkouts.md
@@ -1,0 +1,20 @@
+# Using sparse checkouts
+
+For some use-cases, especially when dealing with monorepos, it can be useful to limit the paths that are checked out
+from the reference repository. It is important to note, that this influences only the shape of the project local
+checkout. The reference repository, maintained by gitman as a cache, will still be a full clone of the original repo.
+
+Using `sparse_paths` will use git's sparse checkout feature to just materialize the selected paths in the working tree.
+As this is a [git feature](https://git-scm.com/docs/git-read-tree#_sparse_checkout), all syntax options are
+available and passed unmodified to `$GIT_DIR/info/sparse-checkout`.
+
+The following example configuration will clone the full font-awesome repo into the cache, but the project local
+clone will only contain the `fonts` directory and it's children.
+
+```yaml
+- name: fontawesome
+  repo: https://github.com/FortAwesome/Font-Awesome
+  sparse_paths:
+  - fonts/*
+  rev: master
+```

--- a/gitman.yml
+++ b/gitman.yml
@@ -20,6 +20,14 @@ sources:
   scripts:
   - echo "Hello, World!"
   - pwd
+- name: gitman_4
+  repo: https://github.com/jacebrowning/gitman-demo
+  rev: example-branch-2
+  link:
+  scripts:
+  -
+  sparse_paths:
+  - docs
 sources_locked:
 - name: gitman_1
   repo: https://github.com/jacebrowning/gitman-demo
@@ -41,3 +49,11 @@ sources_locked:
   scripts:
   - echo "Hello, World!"
   - pwd
+- name: gitman_4
+  repo: https://github.com/jacebrowning/gitman-demo
+  rev: ddbe17ef173538d1fda29bd99a14bab3c5d86e78
+  link:
+  scripts:
+  -
+  sparse_paths:
+  - src

--- a/gitman.yml
+++ b/gitman.yml
@@ -26,8 +26,6 @@ sources:
   link:
   scripts:
   -
-  sparse_paths:
-  - docs
 sources_locked:
 - name: gitman_1
   repo: https://github.com/jacebrowning/gitman-demo
@@ -52,7 +50,7 @@ sources_locked:
 - name: gitman_4
   repo: https://github.com/jacebrowning/gitman-demo
   sparse_paths:
-  - src
+  - src/*
   rev: ddbe17ef173538d1fda29bd99a14bab3c5d86e78
   link:
   scripts:

--- a/gitman.yml
+++ b/gitman.yml
@@ -51,9 +51,9 @@ sources_locked:
   - pwd
 - name: gitman_4
   repo: https://github.com/jacebrowning/gitman-demo
+  sparse_paths:
+  - src
   rev: ddbe17ef173538d1fda29bd99a14bab3c5d86e78
   link:
   scripts:
   -
-  sparse_paths:
-  - src

--- a/gitman/git.py
+++ b/gitman/git.py
@@ -29,7 +29,7 @@ def clone(repo, path, *, cache=settings.CACHE, sparse_paths=None):
         git('clone', '--mirror', repo, reference)
 
     normpath = os.path.normpath(path)
-    if len(sparse_paths) > 0:
+    if sparse_paths:
         os.mkdir(normpath)
         git('-C', normpath, 'init')
         git('-C', normpath, 'config', 'core.sparseCheckout', 'true')
@@ -40,7 +40,8 @@ def clone(repo, path, *, cache=settings.CACHE, sparse_paths=None):
         with open("%s/%s/.git/objects/info/alternates" % (os.getcwd(), normpath), 'w') as fd:
             fd.write("%s/objects" % reference)
 
-        # We use `HEAD` here in order to respect, that not all repos have `master` as their default branch
+        # We use `HEAD` here in order to respect,
+        # that not all repos have `master` as their default branch
         git('-C', normpath, 'pull', 'origin', 'HEAD')
     else:
         git('clone', '--reference', reference, repo, os.path.normpath(path))

--- a/gitman/git.py
+++ b/gitman/git.py
@@ -16,7 +16,7 @@ def git(*args, **kwargs):
     return call('git', *args, **kwargs)
 
 
-def clone(repo, path, *, cache=settings.CACHE, sparse_paths=None):
+def clone(repo, path, *, cache=settings.CACHE, sparse_paths=None, rev=None):
     """Clone a new Git repository."""
     log.debug("Creating a new repository...")
 
@@ -40,9 +40,9 @@ def clone(repo, path, *, cache=settings.CACHE, sparse_paths=None):
         with open("%s/%s/.git/objects/info/alternates" % (os.getcwd(), normpath), 'w') as fd:
             fd.write("%s/objects" % reference)
 
-        # We use `HEAD` here in order to respect,
+        # We use directly the revision requested here in order to respect,
         # that not all repos have `master` as their default branch
-        git('-C', normpath, 'pull', 'origin', 'HEAD')
+        git('-C', normpath, 'pull', 'origin', rev)
     else:
         git('clone', '--reference', reference, repo, os.path.normpath(path))
 

--- a/gitman/git.py
+++ b/gitman/git.py
@@ -16,7 +16,7 @@ def git(*args, **kwargs):
     return call('git', *args, **kwargs)
 
 
-def clone(repo, path, *, cache=settings.CACHE):
+def clone(repo, path, *, cache=settings.CACHE, sparse_paths=None):
     """Clone a new Git repository."""
     log.debug("Creating a new repository...")
 
@@ -28,7 +28,22 @@ def clone(repo, path, *, cache=settings.CACHE):
     if not os.path.isdir(reference):
         git('clone', '--mirror', repo, reference)
 
-    git('clone', '--reference', reference, repo, os.path.normpath(path))
+    normpath = os.path.normpath(path)
+    if len(sparse_paths) > 0:
+        os.mkdir(normpath)
+        git('-C', normpath, 'init')
+        git('-C', normpath, 'config', 'core.sparseCheckout', 'true')
+        git('-C', normpath, 'remote', 'add', '-f', 'origin', reference)
+
+        with open("%s/%s/.git/info/sparse-checkout" % (os.getcwd(), normpath), 'w') as fd:
+            fd.writelines(sparse_paths)
+        with open("%s/%s/.git/objects/info/alternates" % (os.getcwd(), normpath), 'w') as fd:
+            fd.write("%s/objects" % reference)
+
+        # We use `HEAD` here in order to respect, that not all repos have `master` as their default branch
+        git('-C', normpath, 'pull', 'origin', 'HEAD')
+    else:
+        git('clone', '--reference', reference, repo, os.path.normpath(path))
 
 
 def fetch(repo, rev=None):

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -13,10 +13,10 @@ log = logging.getLogger(__name__)
 
 @yorm.attr(name=String)
 @yorm.attr(repo=String)
+@yorm.attr(sparse_paths=List.of_type(String))
 @yorm.attr(rev=String)
 @yorm.attr(link=NullableString)
 @yorm.attr(scripts=List.of_type(String))
-@yorm.attr(sparse_paths=List.of_type(String))
 class Source(AttributeDictionary):
     """A dictionary of `git` and `ln` arguments."""
 

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -61,7 +61,7 @@ class Source(AttributeDictionary):
 
         # Clone the repository if needed
         if not os.path.exists(self.name):
-            git.clone(self.repo, self.name, sparse_paths=self.sparse_paths)
+            git.clone(self.repo, self.name, sparse_paths=self.sparse_paths, rev=self.rev)
 
         # Enter the working tree
         shell.cd(self.name)

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -16,19 +16,21 @@ log = logging.getLogger(__name__)
 @yorm.attr(rev=String)
 @yorm.attr(link=NullableString)
 @yorm.attr(scripts=List.of_type(String))
+@yorm.attr(sparse_paths=List.of_type(String))
 class Source(AttributeDictionary):
     """A dictionary of `git` and `ln` arguments."""
 
     DIRTY = '<dirty>'
     UNKNOWN = '<unknown>'
 
-    def __init__(self, repo, name=None, rev='master', link=None, scripts=None):
+    def __init__(self, repo, name=None, rev='master', link=None, scripts=None, sparse_paths=None):
         super().__init__()
         self.repo = repo
         self.name = self._infer_name(repo) if name is None else name
         self.rev = rev
         self.link = link
         self.scripts = scripts or []
+        self.sparse_paths = sparse_paths or []
 
         for key in ['name', 'repo', 'rev']:
             if not self[key]:
@@ -59,7 +61,7 @@ class Source(AttributeDictionary):
 
         # Clone the repository if needed
         if not os.path.exists(self.name):
-            git.clone(self.repo, self.name)
+            git.clone(self.repo, self.name, sparse_paths=self.sparse_paths)
 
         # Enter the working tree
         shell.cd(self.name)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ pages:
   - Tracking Branches: use-cases/branch-tracking.md
   - Linking Feature Branches: use-cases/linked-features.md
   - Build System Integration: use-cases/build-integration.md
+  - Sparse Checkouts: use-cases/sparse-checkouts.md
 - About:
   - Release Notes: about/changelog.md
   - Contributing: about/contributing.md

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,17 +29,23 @@ sources:
   link:
   scripts:
   -
+  sparse_paths:
+  -
 - name: gitman_2
   repo: https://github.com/jacebrowning/gitman-demo
   rev: example-tag
   link:
   scripts:
   -
+  sparse_paths:
+  -
 - name: gitman_3
   repo: https://github.com/jacebrowning/gitman-demo
   rev: 9bf18e16b956041f0267c21baad555a23237b52e
   link:
   scripts:
+  -
+  sparse_paths:
   -
 """.lstrip()
 
@@ -83,12 +89,16 @@ def describe_init():
           link:
           scripts:
           -
+          sparse_paths:
+          -
         sources_locked:
         - name: sample_dependency
           repo: https://github.com/githubtraining/hellogitworld
           rev: ebbbf773431ba07510251bb03f9525c7bab2b13a
           link:
           scripts:
+          -
+          sparse_paths:
           -
         """)
 
@@ -309,11 +319,15 @@ def describe_update():
           link:
           scripts:
           -
+          sparse_paths:
+          -
         - name: gitman_2
           repo: https://github.com/jacebrowning/gitman-demo
           rev: example-tag
           link:
           scripts:
+          -
+          sparse_paths:
           -
         sources_locked:
         - name: gitman_2
@@ -321,6 +335,8 @@ def describe_update():
           rev: (old revision)
           link:
           scripts:
+          -
+          sparse_paths:
           -
         """)
 
@@ -335,11 +351,15 @@ def describe_update():
           link:
           scripts:
           -
+          sparse_paths:
+          -
         - name: gitman_2
           repo: https://github.com/jacebrowning/gitman-demo
           rev: example-tag
           link:
           scripts:
+          -
+          sparse_paths:
           -
         sources_locked:
         - name: gitman_2
@@ -347,6 +367,8 @@ def describe_update():
           rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
           link:
           scripts:
+          -
+          sparse_paths:
           -
         """)
 
@@ -360,11 +382,15 @@ def describe_update():
           link:
           scripts:
           -
+          sparse_paths:
+          -
         - name: gitman_2
           repo: https://github.com/jacebrowning/gitman-demo
           rev: example-tag
           link:
           scripts:
+          -
+          sparse_paths:
           -
         sources_locked:
         - name: gitman_2
@@ -372,6 +398,8 @@ def describe_update():
           rev: (old revision)
           link:
           scripts:
+          -
+          sparse_paths:
           -
         """)
 
@@ -386,11 +414,15 @@ def describe_update():
           link:
           scripts:
           -
+          sparse_paths:
+          -
         - name: gitman_2
           repo: https://github.com/jacebrowning/gitman-demo
           rev: example-tag
           link:
           scripts:
+          -
+          sparse_paths:
           -
         sources_locked:
         - name: gitman_2
@@ -398,6 +430,8 @@ def describe_update():
           rev: (old revision)
           link:
           scripts:
+          -
+          sparse_paths:
           -
         """)
 
@@ -412,17 +446,23 @@ def describe_update():
           link:
           scripts:
           -
+          sparse_paths:
+          -
         - name: gitman_2
           repo: https://github.com/jacebrowning/gitman-demo
           rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
           link:
           scripts:
           -
+          sparse_paths:
+          -
         - name: gitman_3
           repo: https://github.com/jacebrowning/gitman-demo
           rev: 9bf18e16b956041f0267c21baad555a23237b52e
           link:
           scripts:
+          -
+          sparse_paths:
           -
         """)
 
@@ -462,17 +502,23 @@ def describe_lock():
           link:
           scripts:
           -
+          sparse_paths:
+          -
         - name: gitman_2
           repo: https://github.com/jacebrowning/gitman-demo
           rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
           link:
           scripts:
           -
+          sparse_paths:
+          -
         - name: gitman_3
           repo: https://github.com/jacebrowning/gitman-demo
           rev: 9bf18e16b956041f0267c21baad555a23237b52e
           link:
           scripts:
+          -
+          sparse_paths:
           -
         """) == config.__mapper__.text
 
@@ -488,11 +534,15 @@ def describe_lock():
           link:
           scripts:
           -
+          sparse_paths:
+          -
         - name: gitman_3
           repo: https://github.com/jacebrowning/gitman-demo
           rev: 9bf18e16b956041f0267c21baad555a23237b52e
           link:
           scripts:
+          -
+          sparse_paths:
           -
         """) == config.__mapper__.text
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -245,6 +245,34 @@ def describe_install():
         def script_failures_can_be_ignored(config_with_scripts):
             expect(gitman.install(force=True)) == True
 
+    def describe_sparse_paths():
+        @pytest.fixture
+        def config_with_scripts(config):
+            config.__mapper__.text = strip("""
+                    location: deps
+                    sources:
+                    - name: gitman_1
+                      repo: https://github.com/jacebrowning/gitman-demo
+                      sparse_paths:
+                      - src/*
+                      rev: ddbe17ef173538d1fda29bd99a14bab3c5d86e78
+                      link:
+                      scripts:
+                      -
+                    """)
+
+            return config
+
+        def it_successfully_materializes_the_repo(config):
+            expect(gitman.install(depth=1, force=True)) == True
+            dir_listing = os.listdir(os.path.join(config.location, "gitman_1"))
+            expect(dir_listing).contains('src')
+
+        def it_contains_only_the_sparse_paths(config):
+            expect(gitman.install(depth=1, force=True)) == True
+            dir_listing = os.listdir(os.path.join(config.location, "gitman_1"))
+            expect(dir_listing).contains('src')
+            expect(len(dir_listing) == 1)
 
 def describe_uninstall():
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -274,6 +274,7 @@ def describe_install():
             expect(dir_listing).contains('src')
             expect(len(dir_listing) == 1)
 
+
 def describe_uninstall():
 
     def it_deletes_dependencies_when_they_exist(config):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -25,27 +25,27 @@ location: deps
 sources:
 - name: gitman_1
   repo: https://github.com/jacebrowning/gitman-demo
+  sparse_paths:
+  -
   rev: example-branch
   link:
   scripts:
   -
-  sparse_paths:
-  -
 - name: gitman_2
   repo: https://github.com/jacebrowning/gitman-demo
+  sparse_paths:
+  -
   rev: example-tag
   link:
   scripts:
   -
-  sparse_paths:
-  -
 - name: gitman_3
   repo: https://github.com/jacebrowning/gitman-demo
+  sparse_paths:
+  -
   rev: 9bf18e16b956041f0267c21baad555a23237b52e
   link:
   scripts:
-  -
-  sparse_paths:
   -
 """.lstrip()
 
@@ -85,20 +85,20 @@ def describe_init():
         sources:
         - name: sample_dependency
           repo: https://github.com/githubtraining/hellogitworld
+          sparse_paths:
+          -
           rev: master
           link:
           scripts:
           -
-          sparse_paths:
-          -
         sources_locked:
         - name: sample_dependency
           repo: https://github.com/githubtraining/hellogitworld
+          sparse_paths:
+          -
           rev: ebbbf773431ba07510251bb03f9525c7bab2b13a
           link:
           scripts:
-          -
-          sparse_paths:
           -
         """)
 
@@ -315,28 +315,28 @@ def describe_update():
         sources:
         - name: gitman_1
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: example-branch
           link:
           scripts:
           -
-          sparse_paths:
-          -
         - name: gitman_2
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: example-tag
           link:
           scripts:
           -
-          sparse_paths:
-          -
         sources_locked:
         - name: gitman_2
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: (old revision)
           link:
           scripts:
-          -
-          sparse_paths:
           -
         """)
 
@@ -347,28 +347,28 @@ def describe_update():
         sources:
         - name: gitman_1
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: example-branch
           link:
           scripts:
           -
-          sparse_paths:
-          -
         - name: gitman_2
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: example-tag
           link:
           scripts:
           -
-          sparse_paths:
-          -
         sources_locked:
         - name: gitman_2
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
           link:
           scripts:
-          -
-          sparse_paths:
           -
         """)
 
@@ -378,28 +378,28 @@ def describe_update():
         sources:
         - name: gitman_1
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: example-branch
           link:
           scripts:
           -
-          sparse_paths:
-          -
         - name: gitman_2
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: example-tag
           link:
           scripts:
           -
-          sparse_paths:
-          -
         sources_locked:
         - name: gitman_2
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: (old revision)
           link:
           scripts:
-          -
-          sparse_paths:
           -
         """)
 
@@ -410,28 +410,28 @@ def describe_update():
         sources:
         - name: gitman_1
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: example-branch
           link:
           scripts:
           -
-          sparse_paths:
-          -
         - name: gitman_2
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: example-tag
           link:
           scripts:
           -
-          sparse_paths:
-          -
         sources_locked:
         - name: gitman_2
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: (old revision)
           link:
           scripts:
-          -
-          sparse_paths:
           -
         """)
 
@@ -442,27 +442,27 @@ def describe_update():
         sources_locked:
         - name: gitman_1
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: 1de84ca1d315f81b035cd7b0ecf87ca2025cdacd
           link:
           scripts:
           -
-          sparse_paths:
-          -
         - name: gitman_2
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
           link:
           scripts:
           -
-          sparse_paths:
-          -
         - name: gitman_3
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: 9bf18e16b956041f0267c21baad555a23237b52e
           link:
           scripts:
-          -
-          sparse_paths:
           -
         """)
 
@@ -498,27 +498,27 @@ def describe_lock():
         sources_locked:
         - name: gitman_1
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: 1de84ca1d315f81b035cd7b0ecf87ca2025cdacd
           link:
           scripts:
           -
-          sparse_paths:
-          -
         - name: gitman_2
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
           link:
           scripts:
           -
-          sparse_paths:
-          -
         - name: gitman_3
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: 9bf18e16b956041f0267c21baad555a23237b52e
           link:
           scripts:
-          -
-          sparse_paths:
           -
         """) == config.__mapper__.text
 
@@ -530,19 +530,19 @@ def describe_lock():
         sources_locked:
         - name: gitman_1
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: 1de84ca1d315f81b035cd7b0ecf87ca2025cdacd
           link:
           scripts:
           -
-          sparse_paths:
-          -
         - name: gitman_3
           repo: https://github.com/jacebrowning/gitman-demo
+          sparse_paths:
+          -
           rev: 9bf18e16b956041f0267c21baad555a23237b52e
           link:
           scripts:
-          -
-          sparse_paths:
           -
         """) == config.__mapper__.text
 


### PR DESCRIPTION
Dear @jacebrowning ,

thanks a lot for building this tool! I highly appreciate that you solved one of my big current problems for me :D

Hereby I propose an addition to gitman, which enables sparse checkouts of the referenced repositories. The PR is **incomplete**, because tests and documentation are still missing for the addition. I wanted to get your feedback as early as possible, but also wanted to have something real to talk about. My python skills are limited, so please bare with me in regards to the chosen implementation.

## What is the value added with this PR?
I use gitman in order to pull together protobuf definitions from different repositories. Most of the remotes do not only carry the protobufs, but also the application that is using it. In order to reduce the clutter in the vendor folder, I'd like to introduce the option to select the paths that are relevant for me. In addition, I frequently work on bigger monorepos, which makes it even more valuable for me.

Before I continue my efforts, I'd like to have your feedback on it and I might need some help setting up the environment correctly. I've managed to test my changes locally, but using the Makefile as stated in the contributors guide leads me to an error related to a missing dependency when attempting to execute the tests.

Cheers!
Mario

Here is a sample log from a successful run:
```
mmueller at Brick in ~/Development/src/gitman-test
$ gitman install -v
[INFO    ] Installing dependencies: <all>
[INFO    ] Defaulting to locked sources...
[INFO    ] $ mkdir -p /Users/mmueller/Development/src/gitman-test/vendor
[INFO    ] $ cd /Users/mmueller/Development/src/gitman-test/vendor
[INFO    ] Updating source files...
[INFO    ] $ git -C sample_dependency init
[INFO    ] $ git -C sample_dependency config core.sparseCheckout true
[INFO    ] $ git -C sample_dependency remote add -f origin /Users/mmueller/.gitcache/hellogitworld.reference
[INFO    ] $ git -C sample_dependency pull origin HEAD
[INFO    ] $ cd sample_dependency
[INFO    ] $ git remote set-url origin https://github.com/githubtraining/hellogitworld
[INFO    ] $ git fetch --tags --force --prune origin
[INFO    ] $ git checkout --force ebbbf773431ba07510251bb03f9525c7bab2b13a
[INFO    ] Defaulting to locked sources...
[INFO    ] $ cd /Users/mmueller/Development/src/gitman-test/vendor
[INFO    ] Running install scripts...
[INFO    ] $ cd sample_dependency
[INFO    ] (no scripts to run)
[INFO    ] Installed 1 dependency
```