### PR TITLE
Refine the heuristic used to recognize commit SHAs

### DIFF
--- a/gitman/git.py
+++ b/gitman/git.py
@@ -3,6 +3,7 @@
 import os
 import logging
 from contextlib import suppress
+import re
 
 from . import common, settings
 from .shell import call
@@ -47,12 +48,22 @@ def clone(repo, path, *, cache=settings.CACHE, sparse_paths=None, rev=None):
         git('clone', '--reference', reference, repo, os.path.normpath(path))
 
 
+def is_sha(rev):
+    """Heuristically determine whether a revision corresponds to a commit SHA.
+
+    Any sequence of 7 to 40 hexadecimal digits will be recognized as a
+    commit SHA. The minimum of 7 digits is not an arbitrary choice, it
+    is the default length for short SHAs in Git.
+    """
+    return re.match('^[0-9a-f]{7,40}$', rev) is not None
+
+
 def fetch(repo, rev=None):
     """Fetch the latest changes from the remote repository."""
     git('remote', 'set-url', 'origin', repo)
     args = ['fetch', '--tags', '--force', '--prune', 'origin']
     if rev:
-        if len(rev) == 40:
+        if is_sha(rev):
             pass  # fetch only works with a SHA if already present locally
         elif '@' in rev:
             pass  # fetch doesn't work with rev-parse


### PR DESCRIPTION
The previous test `len(rev) == 40` does not allow for short SHAs, and
would incorrectly identify a 40-char branch or tag name as a SHA.
A better trade-off is to require `rev` to be a sequence of hexadecimal
digits in order to be recognized as a SHA, while allowing SHAs shorter
than 40 digits.