### PR TITLE
Improve PyInstaller build for Windows (remove --windowed option)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ $(EXE_FILES): $(MODULES) $(PACKAGE).spec
 	poetry run pyinstaller $(PACKAGE).spec --noconfirm --clean
 
 $(PACKAGE).spec:
-	poetry run pyi-makespec $(PACKAGE)/__main__.py --onefile --windowed --additional-hooks-dir=gitman --name=$(PACKAGE)
+	poetry run pyi-makespec $(PACKAGE)/__main__.py --onefile --additional-hooks-dir=gitman --name=$(PACKAGE)
 
 # RELEASE #####################################################################
 


### PR DESCRIPTION
Checked on linux and windows...