### PR TITLE
Added symbolic link support for Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,9 @@ environment:
 cache:
   - .venv -> poetry.lock
 
+init: 
+  - git config --global core.symlinks true
+
 install:
   # Add Make and Python to the PATH
   - copy C:\MinGW\bin\mingw32-make.exe C:\MinGW\bin\make.exe

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import warnings
 
 import yorm
 from yorm.types import AttributeDictionary, List, NullableString, String

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -166,7 +166,7 @@ class Source(AttributeDictionary):
                 msg = "Preexisting link location at {}".format(target)
                 raise exceptions.UncommittedChanges(msg)
 
-        os.symlink(source, target)
+        shell.ln(source, target)
 
     def run_scripts(self, force=False):
         log.info("Running install scripts...")

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -155,10 +155,6 @@ class Source(AttributeDictionary):
 
         log.info("Creating a symbolic link...")
 
-        if os.name == 'nt':
-            warnings.warn("Symbolic links are not supported on Windows")
-            return
-
         target = os.path.join(root, self.link)
         source = os.path.relpath(os.getcwd(), os.path.dirname(target))
 
@@ -171,7 +167,7 @@ class Source(AttributeDictionary):
                 msg = "Preexisting link location at {}".format(target)
                 raise exceptions.UncommittedChanges(msg)
 
-        shell.ln(source, target)
+        os.symlink(source, target)
 
     def run_scripts(self, force=False):
         log.info("Running install scripts...")

--- a/gitman/shell.py
+++ b/gitman/shell.py
@@ -76,13 +76,10 @@ def cd(path, _show=True):
 
 
 def ln(source, target):
-    if os.name == 'nt':
-        log.warning("Symlinks are not supported on Windows")
-    else:
-        dirpath = os.path.dirname(target)
-        if not os.path.isdir(dirpath):
-            mkdir(dirpath)
-        call('ln', '-s', source, target)
+    dirpath = os.path.dirname(target)
+    if not os.path.isdir(dirpath):
+        mkdir(dirpath)
+    os.symlink(source, target)
 
 
 def rm(path):

--- a/gitman/tests/test_shell.py
+++ b/gitman/tests/test_shell.py
@@ -54,23 +54,24 @@ class TestPrograms:
         check_calls(mock_call, [])
 
     @patch('os.path.isdir', Mock(return_value=True))
-    def test_ln(self, mock_call):
+    @patch('os.symlink')
+    def test_ln(self, mock_symlink, mock_call):
         """Verify the commands to create symbolic links."""
         shell.ln('mock/target', 'mock/source')
-        if os.name == 'nt':
-            check_calls(mock_call, [])
-        else:
-            check_calls(mock_call, ["ln -s mock/target mock/source"])
+        mock_symlink.assert_called_once_with('mock/target', 'mock/source')
+        check_calls(mock_call, [])
 
     @patch('os.path.isdir', Mock(return_value=False))
     @patch('os.path.exists', Mock(return_value=False))
-    def test_ln_missing_parent(self, mock_call):
+    @patch('os.symlink')
+    def test_ln_missing_parent(self, mock_symlink, mock_call):
         """Verify the commands to create symbolic links (missing parent)."""
         shell.ln('mock/target', 'mock/source')
+        mock_symlink.assert_called_once_with('mock/target', 'mock/source')
         if os.name == 'nt':
-            check_calls(mock_call, [])
+            check_calls(mock_call, ["mkdir mock"])
         else:
-            check_calls(mock_call, ["mkdir -p mock", "ln -s mock/target mock/source"])
+            check_calls(mock_call, ["mkdir -p mock"])
 
     @patch('os.path.isfile', Mock(return_value=True))
     def test_rm_file(self, mock_call):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -218,13 +218,11 @@ def describe_install():
 
             return config
 
-        @pytest.mark.xfail(os.name == 'nt', reason="No symlinks on Windows")
         def it_should_create_links(config_with_link):
             expect(gitman.install(depth=1)) == True
 
             expect(os.listdir()).contains('my_link')
 
-        @pytest.mark.xfail(os.name == 'nt', reason="No symlinks on Windows")
         def it_should_not_overwrite_files(config_with_link):
             os.system("touch my_link")
 


### PR DESCRIPTION
Hi, from Python Documentation: "Symbolic link support was introduced in Windows 6.0 (Vista). symlink() will raise a NotImplementedError on Windows versions earlier than 6.0." (https://docs.python.org/3.6/library/os.html#os.symlink)