### PR TITLE
Feature/repo rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Added basic group support. (@daniel-brosche)
 - Improved validity check of git repo (@mttjohnson)
-- Added rebuilding missing repo on `install` (@mttjohnson)
+- Added rebuilding missing repo on `install --force` (@mttjohnson)
 - Added `--force-interactive` option to interactively overwrite changed dependencies on install or update command. (@daniel-brosche)
 - **BREAKING**: Renamed `-f` alias to `-F` (`-f` now implies `--force-interactive`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 1.7 (unreleased)
 
 - Added basic group support. (@daniel-brosche)
+- Improved validity check of git repo (@mttjohnson)
+- Added rebuilding missing repo on `install` (@mttjohnson)
 - Added `--force-interactive` option to interactively overwrite changed dependencies on install or update command. (@daniel-brosche)
 - **BREAKING**: Renamed `-f` alias to `-F` (`-f` now implies `--force-interactive`).
 

--- a/gitman/git.py
+++ b/gitman/git.py
@@ -135,7 +135,7 @@ def rebuild(type, repo):  # pylint: disable=unused-argument
     """Rebuild a missing repo .git directory."""
 
     if type == 'git-svn':
-        # unkown support
+        # ignore rebuild in case of git-svn
         return
 
     assert type == 'git'

--- a/gitman/git.py
+++ b/gitman/git.py
@@ -114,15 +114,15 @@ def valid():
     log.debug("Checking for a valid git top level...")
     gittoplevel = git('rev-parse', '--show-toplevel', _show=False)
     currentdir = pwd(_show=False)
-    if gittoplevel == currentdir:
+    if gittoplevel[0] == currentdir:
         return True
     else:
+        log.debug(f'git top level: {gittoplevel[0]} != current working directory: {currentdir}')
         return False
 
 
 def rebuild(type, repo):  # pylint: disable=unused-argument
     """Rebuild a missing repo .git directory"""
-    log.debug("Rebuilding mising git repo...")
 
     if type == 'git-svn':
         # unkown support
@@ -130,8 +130,10 @@ def rebuild(type, repo):  # pylint: disable=unused-argument
 
     assert type == 'git'
 
-    git('init')
-    git('remote', 'add', 'origin', repo)
+    common.show("Rebuilding mising git repo...", color='message')
+    git('init', _show=True)
+    git('remote', 'add', 'origin', repo, _show=True)
+    common.show("Rebuilt git repo...", color='message')
 
 
 def changes(type, include_untracked=False, display_status=True, _show=False):

--- a/gitman/git.py
+++ b/gitman/git.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 
 from . import common, settings
 from .exceptions import ShellError
-from .shell import call
+from .shell import call, pwd
 
 
 log = logging.getLogger(__name__)
@@ -101,15 +101,37 @@ def fetch(type, repo, path, rev=None):  # pylint: disable=unused-argument
 
 
 def valid():
-    """Confirm the current directory is a valid working tree."""
+    """Confirm the current directory is a valid working tree.
+    Ensure current directory is is the toplevel directory.
+    """
     log.debug("Checking for a valid working tree...")
 
     try:
         git('rev-parse', '--is-inside-work-tree', _show=False)
     except ShellError:
         return False
-    else:
+
+    log.debug("Checking for a valid git top level...")
+    gittoplevel = git('rev-parse', '--show-toplevel', _show=False)
+    currentdir = pwd(_show=False)
+    if gittoplevel == currentdir:
         return True
+    else:
+        return False
+
+
+def rebuild(type, repo):  # pylint: disable=unused-argument
+    """Rebuild a missing repo .git directory"""
+    log.debug("Rebuilding mising git repo...")
+
+    if type == 'git-svn':
+        # unkown support
+        return
+
+    assert type == 'git'
+
+    git('init')
+    git('remote', 'add', 'origin', repo)
 
 
 def changes(type, include_untracked=False, display_status=True, _show=False):

--- a/gitman/git.py
+++ b/gitman/git.py
@@ -102,8 +102,11 @@ def fetch(type, repo, path, rev=None):  # pylint: disable=unused-argument
 
 def valid():
     """Confirm the current directory is a valid working tree.
-    Ensure current directory is is the toplevel directory.
+
+    Checking both the git working tree exists and that the top leve
+    directory path matches the current directory path.
     """
+
     log.debug("Checking for a valid working tree...")
 
     try:
@@ -114,15 +117,22 @@ def valid():
     log.debug("Checking for a valid git top level...")
     gittoplevel = git('rev-parse', '--show-toplevel', _show=False)
     currentdir = pwd(_show=False)
+
+    status = False
     if gittoplevel[0] == currentdir:
-        return True
+        status = True
     else:
-        log.debug(f'git top level: {gittoplevel[0]} != current working directory: {currentdir}')
-        return False
+        log.debug(
+            "git top level: %s != current working directory: %s",
+            gittoplevel[0],
+            currentdir,
+        )
+        status = False
+    return status
 
 
 def rebuild(type, repo):  # pylint: disable=unused-argument
-    """Rebuild a missing repo .git directory"""
+    """Rebuild a missing repo .git directory."""
 
     if type == 'git-svn':
         # unkown support

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -95,7 +95,10 @@ class Source(AttributeDictionary):
         # Enter the working tree
         shell.cd(self.name)
         if not git.valid():
-            raise self._invalid_repository
+            if force:
+                git.rebuild(self.type, self.repo)
+            else:
+                raise self._invalid_repository
 
         # Check for uncommitted changes
         if not force:

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -97,6 +97,7 @@ class Source(AttributeDictionary):
         if not git.valid():
             if force:
                 git.rebuild(self.type, self.repo)
+                fetch=True
             else:
                 raise self._invalid_repository
 
@@ -272,7 +273,11 @@ class Source(AttributeDictionary):
     @property
     def _invalid_repository(self):
         path = os.path.join(os.getcwd(), self.name)
-        msg = "Not a valid repository: {}".format(path)
+        msg = """
+            
+            Not a valid repository: {}
+            During install you can rebuild a repo with a missing .git directory using the --force option
+            """.format(path)
         return exceptions.InvalidRepository(msg)
 
     @staticmethod

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -97,7 +97,7 @@ class Source(AttributeDictionary):
         if not git.valid():
             if force:
                 git.rebuild(self.type, self.repo)
-                fetch=True
+                fetch = True
             else:
                 raise self._invalid_repository
 
@@ -277,7 +277,9 @@ class Source(AttributeDictionary):
             
             Not a valid repository: {}
             During install you can rebuild a repo with a missing .git directory using the --force option
-            """.format(path)
+            """.format(
+            path
+        )
         return exceptions.InvalidRepository(msg)
 
     @staticmethod

--- a/gitman/shell.py
+++ b/gitman/shell.py
@@ -77,10 +77,7 @@ def cd(path, _show=True):
 
 def pwd(_show=True):
     cwd = os.getcwd()
-    if os.name == 'nt':
-        show('cwd', '/D', cwd, stdout=_show)
-    else:
-        show('cwd', cwd, stdout=_show)
+    show('cwd', cwd, stdout=_show)
     return cwd
 
 

--- a/gitman/shell.py
+++ b/gitman/shell.py
@@ -77,6 +77,8 @@ def cd(path, _show=True):
 
 def pwd(_show=True):
     cwd = os.getcwd()
+    if os.name == 'nt':
+        cwd = cwd.replace(os.sep, '/')
     show('cwd', cwd, stdout=_show)
     return cwd
 

--- a/gitman/shell.py
+++ b/gitman/shell.py
@@ -75,6 +75,15 @@ def cd(path, _show=True):
     os.chdir(path)
 
 
+def pwd(_show=True):
+    cwd = os.getcwd()
+    if os.name == 'nt':
+        show('cwd', '/D', cwd, stdout=_show)
+    else:
+        show('cwd', cwd, stdout=_show)
+    return cwd
+
+
 def ln(source, target):
     dirpath = os.path.dirname(target)
     if not os.path.isdir(dirpath):

--- a/gitman/tests/test_git.py
+++ b/gitman/tests/test_git.py
@@ -102,7 +102,10 @@ class TestGit:
     def test_valid(self, mock_call):
         """Verify the commands to check for a working tree."""
         git.valid()
-        check_calls(mock_call, ["git rev-parse --is-inside-work-tree"])
+        check_calls(
+            mock_call,
+            ["git rev-parse --is-inside-work-tree", "git rev-parse --show-toplevel"],
+        )
 
     def test_changes(self, mock_call):
         """Verify the commands to check for uncommitted changes."""

--- a/gitman/tests/test_git.py
+++ b/gitman/tests/test_git.py
@@ -99,13 +99,38 @@ class TestGit:
             ],
         )
 
-    def test_valid(self, mock_call):
-        """Verify the commands to check for a working tree."""
-        git.valid()
+    @patch('os.getcwd', Mock(return_value='mock/outside_repo/nested_repo'))
+    def test_valid(self, _):
+        """Verify the commands to check for a working tree and is toplevel of repo."""
+        with patch(
+            'gitman.git.call', Mock(return_value=['mock/outside_repo/nested_repo'])
+        ):
+            assert True is git.valid()
+
+    @patch('os.getcwd', Mock(return_value='mock/outside_repo/nested_repo'))
+    def test_valid_false_outside_work_tree(self, _):
+        """Verify a shell error indicating it is not in a working tree returns false."""
+        with patch('gitman.git.call', Mock(side_effect=ShellError)):
+            assert False is git.valid()
+
+    @patch('os.getcwd', Mock(return_value='mock/outside_repo/nested_repo'))
+    def test_valid_false_current_not_toplevel(self, _):
+        """Verify git toplevel matches current directory"""
+        with patch('gitman.git.call', Mock(return_value=['mock/outside_repo'])):
+            assert False is git.valid()
+
+    def test_rebuild(self, mock_call):
+        """Verify the commands to rebuild a Git repository"""
+        git.rebuild('git', 'master@{2015-02-12 18:30:00}')
         check_calls(
             mock_call,
-            ["git rev-parse --is-inside-work-tree", "git rev-parse --show-toplevel"],
+            ["git init", "git remote add origin master@{2015-02-12 18:30:00}"],
         )
+
+    def test_rebuild_gitsvn(self, mock_call):
+        """Verify the rebuild is ignored with git-svn type"""
+        git.rebuild('git-svn', 'master@{2015-02-12 18:30:00}')
+        check_calls(mock_call, [])
 
     def test_changes(self, mock_call):
         """Verify the commands to check for uncommitted changes."""

--- a/gitman/tests/test_shell.py
+++ b/gitman/tests/test_shell.py
@@ -54,15 +54,13 @@ class TestPrograms:
         check_calls(mock_call, [])
 
     @patch('os.getcwd', Mock(return_value='mock/dirpath'))
-    @patch('os.chdir')
-    def test_pwd(self, mock_chdir, mock_call):
+    @patch('gitman.shell.show')
+    def test_pwd(self, mock_show, mock_call):
         """Verify the commands to get current working directory."""
-        shell.cd('mock/dirpath')
-        mock_chdir.assert_called_once_with('mock/dirpath')
+        result = shell.pwd()
+        mock_show.assert_called_once_with('cwd', 'mock/dirpath', stdout=True)
         check_calls(mock_call, [])
-
-        cwd = shell.pwd()
-        expect(cwd) == 'mock/dirpath'
+        assert 'mock/dirpath' == result
 
     @patch('os.path.isdir', Mock(return_value=True))
     @patch('os.symlink')

--- a/gitman/tests/test_shell.py
+++ b/gitman/tests/test_shell.py
@@ -53,6 +53,17 @@ class TestPrograms:
         mock_chdir.assert_called_once_with('mock/dirpath')
         check_calls(mock_call, [])
 
+    @patch('os.getcwd', Mock(return_value='mock/dirpath'))
+    @patch('os.chdir')
+    def test_pwd(self, mock_chdir, mock_call):
+        """Verify the commands to get current working directory."""
+        shell.cd('mock/dirpath')
+        mock_chdir.assert_called_once_with('mock/dirpath')
+        check_calls(mock_call, [])
+
+        cwd = shell.pwd()
+        expect(cwd) == 'mock/dirpath'
+
     @patch('os.path.isdir', Mock(return_value=True))
     @patch('os.symlink')
     def test_ln(self, mock_symlink, mock_call):


### PR DESCRIPTION
I ran into a situation where running `gitman install` did not throw an exception and instead altered a bunch of files inadvertently in a parent directory. 

I had existing directories under _gitman_sources where the contents of repos existed but the .git directories there did not exist. I consider that this could happen from backups that fail to backup the .git directory but backup other contents, or some accidental deletion of the .git directory.

```
parent_repo
├── .git
│   └── ,,,
├── gitman.yml
└── gitman_sources
    └── child_repo
        └── README.md
```

When running `gitman install` gitman would check to see if the child_repo directory existed, then run the git.verify() to check and make sure it was in a git work tree, and that came back true because there was a directory above that was a valid git repo even though it wasn't for a repo in the directory it through it was checking for. It then continued by changing the remote of the parent repo, fetching all of it's contents, then running a force checkout to the commit hash that had been locked in the `gitman.yml` file. It was the force checkout that rewrote the contents of the parent repo loosing anything that had existed there previously.

```
cd parent_repo/gitman_sources
  $ cd child_repo
  $ git remote set-url origin git@github.com:example/example.git
  $ git fetch --tags --force --prune origin
  $ git checkout --force abcdef1234
```

I found what I needed it to do instead when a .git directory was missing so that it would rebuild the child_repo correctly even though the .git directory was missing by initializing a new git repo, adding a remote, and letting it do all the other things it normally would.

```
cd parent_repo/gitman_sources
  $ cd child_repo
  $ git init
  $ git remote add origin git@github.com:example/example.git
  $ git remote set-url origin git@github.com:example/example.git
  $ git fetch --tags --force --prune origin
  $ git checkout --force abcdef1234
```

I made changes to the `gitman.git.verify()` method to check the toplevel of the git repo and verify that it matches the current directory so that it could detect if the git work tree that returned true was for the directory it was in. This helps prevent the catastrophic affect that I had seen where it modified all kinds of contents outside of where it was supposed to affect. I then added the additional feature to rebuild a git repo `gitman.git.rebuild()` so that if I could have it rebuild a repo properly if the .git directory was missing. Since I figured this wasn't the best default behavior I had it check for a `--force` option on the cli call. This allows for `gitman install` to properly throw an exception if it finds contents in the child_repo directory that isn't a functional repo and a parent repo exists. I also included a hint in the exception that if called with `--force` it could rebuild the `child_repo`. Calling `gitman install --force` would then run the rebuild and restore the `child_repo` correctly. 

I wasn't sure if there should be a separate flag for allowing the rebuild to occur when an invalid `child_rep` was detected, so I reused the `--force` flag for this purpose.

I didn't have an opportunity to test this on windows for git-svn, but I tried writing test for all my new code, and ensuring that everything passed and I maintained test coverage.

This is my first attempt at writing python code and tests, so I have no idea if this is done the correct way, but I was able to make it function the way I was needing it, and the tests all seem to pass and exercise what I thought was needed.