### PR TITLE
Add check for empty checkout destination

### DIFF
--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -60,7 +60,14 @@ class Source:
 
         # Clone the repository if needed
         assert self.name
-        if not os.path.exists(self.name) or len(os.listdir(self.name)) == 0:
+        valid_checkout_dir = False
+        # if os.path.exists(self.name):
+        if os.path.isdir(self.name):
+            valid_checkout_dir = len(os.listdir(self.name)) == 0
+        else:
+            valid_checkout_dir = True
+
+        if valid_checkout_dir:
             git.clone(
                 self.type,
                 self.repo,

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -61,7 +61,6 @@ class Source:
         # Clone the repository if needed
         assert self.name
         valid_checkout_dir = False
-        # if os.path.exists(self.name):
         if os.path.isdir(self.name):
             valid_checkout_dir = len(os.listdir(self.name)) == 0
         else:

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -60,7 +60,7 @@ class Source:
 
         # Clone the repository if needed
         assert self.name
-        if not os.path.exists(self.name):
+        if not os.path.exists(self.name) or len(os.listdir(self.name)) == 0:
             git.clone(
                 self.type,
                 self.repo,

--- a/gitman/tests/test_models_source.py
+++ b/gitman/tests/test_models_source.py
@@ -91,7 +91,8 @@ class TestSource:
             'git', 'repo', 'name', clean=True, fetch=False, rev='rev'
         )
 
-    @patch('os.path.exists', Mock(return_value=True))
+    @patch('os.path.isdir', Mock(return_value=True))
+    @patch('os.listdir', Mock(return_value=['test_file']))
     @patch('gitman.shell.cd', Mock(return_value=True))
     @patch('gitman.git.valid', Mock(return_value=False))
     @patch('gitman.git.changes', Mock(return_value=False))
@@ -113,7 +114,8 @@ class TestSource:
         mock_fetch.assert_not_called()
         mock_update.assert_not_called()
 
-    @patch('os.path.exists', Mock(return_value=True))
+    @patch('os.path.isdir', Mock(return_value=True))
+    @patch('os.listdir', Mock(return_value=['test_file']))
     @patch('gitman.shell.cd', Mock(return_value=True))
     @patch('gitman.git.valid', Mock(return_value=False))
     @patch('gitman.git.changes', Mock(return_value=False))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -231,6 +231,12 @@ def describe_install():
             expect(os.listdir()).contains('my_link')
 
         def it_should_not_overwrite_files(config_with_link):
+            os.system("touch my_link")
+
+            with pytest.raises(RuntimeError):
+                gitman.install(depth=1)
+
+        def it_should_not_overwrite_non_empty_directories(config_with_link):
             os.system("mkdir my_link")
             os.system("touch mylink/my_link")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -231,7 +231,8 @@ def describe_install():
             expect(os.listdir()).contains('my_link')
 
         def it_should_not_overwrite_files(config_with_link):
-            os.system("touch my_link")
+            os.system("mkdir my_link")
+            os.system("touch mylink/my_link")
 
             with pytest.raises(RuntimeError):
                 gitman.install(depth=1)


### PR DESCRIPTION
Description:
Allow for checkout if destination is empty, previously when empty checkout destination existed gitman failed to checkout the source, but `git checkout` would.

Issue:
See issue https://github.com/jacebrowning/gitman/issues/228


