### PR TITLE
Feature/236 default group

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ groups:
     members:
       - fontawesome
       - material-design-icons
+
+default_group: 'code'
 ```
 
 Ignore the dependency storage location:

--- a/docs/use-cases/default-groups.md
+++ b/docs/use-cases/default-groups.md
@@ -1,0 +1,49 @@
+# Specifying a Default Group
+
+Using the `default_group` attribute in gitman.yml specifies which group of 
+dependencies to install if no inputs are provided to `gitman install`. If 
+if is set to a blank string, `default_group: ''`, then all sources are 
+installed.
+
+When nested gitman projects are used default groups are installed if they
+exist. In the case of the following project layout:
+
+Project A gitman.yml
+
+```yaml
+location: dependencies
+sources:
+  - name: b
+    type: git
+    repo: https://project_b
+    rev: master
+```
+
+Project B gitman.yml
+
+```yaml
+location: dependencies
+sources:
+  - name: c
+    type: git
+    repo: https://project_c
+    rev: master
+  - name: d
+    type: git
+    repo: https://project_d
+    rev: master
+  groups:
+    - name: group_c_d
+      members:
+        - c
+        - d
+    - name: group_d
+      members:
+        - d
+  - default_group: 'group_d'
+```
+
+When `gitman install` is invoked from project A then project B is installed.
+As project B is installed the default group `group_d` will be installed, unless
+`gitman install -n` or `gitman install --no-defaults` is specified which will result in all of project B's
+dependencies (both c and d) being installed.

--- a/gitman/cli.py
+++ b/gitman/cli.py
@@ -255,7 +255,9 @@ def _get_command(function, namespace):  # pylint: disable=too-many-statements
             skip_changes=namespace.skip_changes,
         )
         if namespace.command == 'install':
-            kwargs.update(fetch=namespace.fetch, all=namespace.no_defaults)
+            kwargs.update(
+                fetch=namespace.fetch, skip_default_group=namespace.no_defaults
+            )
         if namespace.command == 'update':
             kwargs.update(recurse=namespace.recurse, lock=namespace.lock)
 

--- a/gitman/cli.py
+++ b/gitman/cli.py
@@ -108,7 +108,7 @@ def main(args=None, function=None):  # pylint: disable=too-many-statements
     sub.add_argument(
         '-n',
         '--no-defaults',
-        help='override default groups and install all dependencies',
+        help='override default groups and install all dependencies if none specified',
         action='store_true',
         dest='no_defaults',
     )

--- a/gitman/cli.py
+++ b/gitman/cli.py
@@ -105,6 +105,13 @@ def main(args=None, function=None):  # pylint: disable=too-many-statements
     sub.add_argument(
         '-e', '--fetch', action='store_true', help="always fetch the latest branches"
     )
+    sub.add_argument(
+        '-n',
+        '--no-defaults',
+        help='override default groups and install all dependencies',
+        action='store_true',
+        dest='no_defaults',
+    )
 
     # Update parser
     info = "update dependencies to the latest versions"
@@ -248,7 +255,7 @@ def _get_command(function, namespace):  # pylint: disable=too-many-statements
             skip_changes=namespace.skip_changes,
         )
         if namespace.command == 'install':
-            kwargs.update(fetch=namespace.fetch)
+            kwargs.update(fetch=namespace.fetch, all=namespace.no_defaults)
         if namespace.command == 'update':
             kwargs.update(recurse=namespace.recurse, lock=namespace.lock)
 

--- a/gitman/commands.py
+++ b/gitman/commands.py
@@ -63,6 +63,7 @@ def install(
     force_interactive=False,
     clean=True,
     skip_changes=False,
+    all=False,
 ):
     """Install dependencies for a project.
 
@@ -102,6 +103,7 @@ def install(
             fetch=fetch,
             clean=clean,
             skip_changes=skip_changes,
+            all=all,
         )
 
         if count:
@@ -123,6 +125,7 @@ def update(
     clean=True,
     lock=None,  # pylint: disable=redefined-outer-name
     skip_changes=False,
+    all=False,
 ):
     """Update dependencies for a project.
 
@@ -165,6 +168,7 @@ def update(
             fetch=True,
             clean=clean,
             skip_changes=skip_changes,
+            all=all,
         )
 
         if count and lock is not False:

--- a/gitman/commands.py
+++ b/gitman/commands.py
@@ -63,7 +63,7 @@ def install(
     force_interactive=False,
     clean=True,
     skip_changes=False,
-    all=False,
+    skip_default_group=False,
 ):
     """Install dependencies for a project.
 
@@ -80,6 +80,8 @@ def install(
     - `clean`: indicates untracked files should be deleted from dependencies
     - `skip_changes`: indicates dependencies with uncommitted changes
      should be skipped
+    - `skip_default_group`: indicates default_group should be skipped if
+     `*names` is empty
     """
     log.info(
         "%sInstalling dependencies: %s",
@@ -103,7 +105,7 @@ def install(
             fetch=fetch,
             clean=clean,
             skip_changes=skip_changes,
-            all=all,
+            skip_default_group=skip_default_group,
         )
 
         if count:
@@ -125,7 +127,7 @@ def update(
     clean=True,
     lock=None,  # pylint: disable=redefined-outer-name
     skip_changes=False,
-    all=False,
+    skip_default_group=False,
 ):
     """Update dependencies for a project.
 
@@ -143,6 +145,8 @@ def update(
     - `lock`: indicates updated dependency versions should be recorded
     - `skip_changes`: indicates dependencies with uncommitted changes
      should be skipped
+    - `skip_default_group`: indicates default_group should be skipped if
+     `*names` is empty
     """
     log.info(
         "%s dependencies%s: %s",
@@ -168,7 +172,7 @@ def update(
             fetch=True,
             clean=clean,
             skip_changes=skip_changes,
-            all=all,
+            skip_default_group=skip_default_group,
         )
 
         if count and lock is not False:

--- a/gitman/models/config.py
+++ b/gitman/models/config.py
@@ -78,7 +78,7 @@ class Config:
         fetch=False,
         clean=True,
         skip_changes=False,
-        all=False,
+        skip_default_group=False,
     ):  # pylint: disable=too-many-locals
         """Download or update the specified dependencies."""
         if depth == 0:
@@ -86,7 +86,9 @@ class Config:
             return 0
 
         sources = self._get_sources(use_locked=False if update else None)
-        sources_filter = self._get_sources_filter(*names, sources=sources, all=all)
+        sources_filter = self._get_sources_filter(
+            *names, sources=sources, skip_default_group=skip_default_group
+        )
 
         if not os.path.isdir(self.location_path):
             shell.mkdir(self.location_path)
@@ -124,7 +126,7 @@ class Config:
                     fetch=fetch,
                     clean=clean,
                     skip_changes=skip_changes,
-                    all=all,
+                    skip_default_group=skip_default_group,
                 )
                 common.dedent()
 
@@ -144,7 +146,9 @@ class Config:
             return 0
 
         sources = self._get_sources()
-        sources_filter = self._get_sources_filter(*names, sources=sources, all=False)
+        sources_filter = self._get_sources_filter(
+            *names, sources=sources, skip_default_group=False
+        )
 
         shell.cd(self.location_path)
         common.newline()
@@ -173,7 +177,9 @@ class Config:
     def lock_dependencies(self, *names, obey_existing=True, skip_changes=False):
         """Lock down the immediate dependency versions."""
         sources = self._get_sources(use_locked=obey_existing).copy()
-        sources_filter = self._get_sources_filter(*names, sources=sources, all=False)
+        sources_filter = self._get_sources_filter(
+            *names, sources=sources, skip_default_group=False
+        )
 
         shell.cd(self.location_path)
         common.newline()
@@ -316,12 +322,12 @@ class Config:
 
         return default_groups
 
-    def _get_sources_filter(self, *names, sources, all):
+    def _get_sources_filter(self, *names, sources, skip_default_group):
         """Get filtered sublist of sources."""
         sources_filter = None
 
         groups_filter = [group for group in self.groups if group.name in list(names)]
-        if not all:
+        if not skip_default_group:
             groups_filter += self._get_default_group(list(names))
 
         if groups_filter:

--- a/gitman/models/config.py
+++ b/gitman/models/config.py
@@ -19,6 +19,7 @@ class Config:
     location: str = "gitman_sources"
     sources: List[Source] = field(default_factory=list)
     sources_locked: List[Source] = field(default_factory=list)
+    default_group: str = field(default_factory=str)
     groups: List[Group] = field(default_factory=list)
 
     def __post_init__(self):
@@ -302,11 +303,19 @@ class Config:
 
         return sources + extras
 
+    def _get_default_group(self, names):
+        """Get default group if names is empty or 'default' is specified."""
+        use_default = 'default' in names or not names
+        default_groups = [group for group in self.groups if group.name == self.default_group and use_default]
+
+        return default_groups
+
     def _get_sources_filter(self, *names, sources):
         """Get filtered sublist of sources."""
         sources_filter = None
-
         groups_filter = [group for group in self.groups if group.name in list(names)]
+        groups_filter += self._get_default_group(list(names))
+        log.info(f"groups_filter: {groups_filter}")
 
         if groups_filter:
             sources_filter = [

--- a/gitman/plugin.py
+++ b/gitman/plugin.py
@@ -59,7 +59,7 @@ def main(args=None):
     parser.add_argument(
         '-n',
         '--no-defaults',
-        help='override default groups and install all dependencies',
+        help='override default groups and install all dependencies if none specified',
         action='store_true',
         dest='no_defaults',
     )

--- a/gitman/plugin.py
+++ b/gitman/plugin.py
@@ -122,6 +122,7 @@ def main(args=None):
 
     # Modify arguments to match CLI interface
     if not namespace.command:
+        # Default to install to remain compatable with older interface
         namespace.command = 'install'
     namespace.name = []
     namespace.root = None

--- a/gitman/plugin.py
+++ b/gitman/plugin.py
@@ -47,6 +47,23 @@ def main(args=None):
     # Options group
     group = parser.add_mutually_exclusive_group()
 
+    # Install option
+    group.add_argument(
+        '-i',
+        '--install',
+        const='install',
+        help='get the specified versions of all dependencies',
+        action='store_const',
+        dest='command',
+    )
+    parser.add_argument(
+        '-n',
+        '--no-defaults',
+        help='override default groups and install all dependencies',
+        action='store_true',
+        dest='no_defaults',
+    )
+
     # Update option
     group.add_argument(
         '-u',

--- a/gitman/tests/test_cli.py
+++ b/gitman/tests/test_cli.py
@@ -77,6 +77,7 @@ class TestInstall:
             fetch=False,
             clean=False,
             skip_changes=False,
+            all=False,
         )
 
     @patch('gitman.commands.install')
@@ -92,6 +93,7 @@ class TestInstall:
             fetch=False,
             clean=False,
             skip_changes=False,
+            all=False,
         )
 
     @patch('gitman.commands.install')
@@ -107,6 +109,7 @@ class TestInstall:
             fetch=False,
             clean=False,
             skip_changes=False,
+            all=False,
         )
 
     @patch('gitman.commands.install')
@@ -122,6 +125,7 @@ class TestInstall:
             fetch=True,
             clean=False,
             skip_changes=False,
+            all=False,
         )
 
     @patch('gitman.commands.install')
@@ -137,6 +141,7 @@ class TestInstall:
             fetch=False,
             clean=True,
             skip_changes=False,
+            all=False,
         )
 
     @patch('gitman.commands.install')
@@ -154,6 +159,7 @@ class TestInstall:
             fetch=False,
             clean=False,
             skip_changes=False,
+            all=False,
         )
 
     @patch('gitman.commands.install')
@@ -169,6 +175,7 @@ class TestInstall:
             fetch=False,
             clean=False,
             skip_changes=False,
+            all=False,
         )
 
     @patch('gitman.commands.install', Mock())

--- a/gitman/tests/test_cli.py
+++ b/gitman/tests/test_cli.py
@@ -77,7 +77,7 @@ class TestInstall:
             fetch=False,
             clean=False,
             skip_changes=False,
-            all=False,
+            skip_default_group=False,
         )
 
     @patch('gitman.commands.install')
@@ -93,7 +93,7 @@ class TestInstall:
             fetch=False,
             clean=False,
             skip_changes=False,
-            all=False,
+            skip_default_group=False,
         )
 
     @patch('gitman.commands.install')
@@ -109,7 +109,7 @@ class TestInstall:
             fetch=False,
             clean=False,
             skip_changes=False,
-            all=False,
+            skip_default_group=False,
         )
 
     @patch('gitman.commands.install')
@@ -125,7 +125,7 @@ class TestInstall:
             fetch=True,
             clean=False,
             skip_changes=False,
-            all=False,
+            skip_default_group=False,
         )
 
     @patch('gitman.commands.install')
@@ -141,7 +141,7 @@ class TestInstall:
             fetch=False,
             clean=True,
             skip_changes=False,
-            all=False,
+            skip_default_group=False,
         )
 
     @patch('gitman.commands.install')
@@ -159,7 +159,7 @@ class TestInstall:
             fetch=False,
             clean=False,
             skip_changes=False,
-            all=False,
+            skip_default_group=False,
         )
 
     @patch('gitman.commands.install')
@@ -175,7 +175,7 @@ class TestInstall:
             fetch=False,
             clean=False,
             skip_changes=False,
-            all=False,
+            skip_default_group=False,
         )
 
     @patch('gitman.commands.install', Mock())

--- a/gitman/tests/test_plugin.py
+++ b/gitman/tests/test_plugin.py
@@ -25,7 +25,7 @@ class TestMain:
                 force=False,
                 force_interactive=False,
                 skip_changes=False,
-                all=False,
+                skip_default_group=False,
             ),
             call.install().__bool__(),  # command status check
         ] == mock_commands.mock_calls

--- a/gitman/tests/test_plugin.py
+++ b/gitman/tests/test_plugin.py
@@ -25,6 +25,7 @@ class TestMain:
                 force=False,
                 force_interactive=False,
                 skip_changes=False,
+                all=False,
             ),
             call.install().__bool__(),  # command status check
         ] == mock_commands.mock_calls

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
       - Linking Feature Branches: use-cases/linked-features.md
       - Build System Integration: use-cases/build-integration.md
       - Sparse Checkouts: use-cases/sparse-checkouts.md
+      - Default Groups: use-cases/default-groups.md
   - Extras:
       - Git SVN Bridge: extras/git-svn.md
       - Self-Contained GitMan: extras/self-contained-gitman.md

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -414,7 +414,7 @@ def describe_install():  # pylint: disable=too-many-statements
             ) == True
 
         def it_installs_all_sources_when_all_specified(config_with_default_group):
-            expect(gitman.install(depth=1, force=True, all=True)) == True
+            expect(gitman.install(depth=1, force=True, skip_default_group=True)) == True
             expect(
                 os.path.exists(
                     os.path.join(config_with_default_group.location, 'gitman_1')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -55,6 +55,7 @@ sources_locked:
   -
 groups:
   -
+default_group: ''
 """.lstrip()
 
 
@@ -109,6 +110,7 @@ def describe_init():
             link:
             scripts:
               -
+        default_group: ''
         groups:
           -
         """
@@ -445,6 +447,7 @@ def describe_update():
               -
         groups:
           -
+        default_group: ''
         """
         )
 
@@ -523,6 +526,7 @@ def describe_update():
               -
         groups:
           -
+        default_group: ''
         """
         )
 
@@ -669,6 +673,7 @@ def describe_update():
             members:
               - gitman_1
               - gitman_2
+        default_group: ''
         """
         )
 
@@ -745,6 +750,7 @@ def describe_update():
               -
         groups:
           -
+        default_group: ''
         """
         )
 
@@ -829,6 +835,7 @@ def describe_update():
               -
         groups:
           -
+        default_group: ''
         """
         )
 


### PR DESCRIPTION
Description:

Proposed changes to add default group support as requested in https://github.com/jacebrowning/gitman/issues/236.

Adds `default_group` attribute to gitman.yml.

New behavior will install sources specified in default group when `gitman install` does not specify any additional arguments. This has the resulting effect of installing `default_group` for any child packages with their own gitman.yml.

Concerns:

As designed this feature will not break any current users, however I could not determine how to get the @datafile Config class to not automatically insert `default_group: ''` into any existing gitman.yml. I don't think this is a concern, but any suggestions on how to avoid this case are appreciated.