### PR TITLE
Add ability to specify groups and sources together during install

### DIFF
--- a/gitman/models/config.py
+++ b/gitman/models/config.py
@@ -313,18 +313,18 @@ class Config:
 
     def _get_sources_filter(self, *names, sources, skip_default_group):
         """Get filtered sublist of sources."""
-        names = list(names)
+        names_list = list(names)
 
-        if not names and not skip_default_group:
-            names.append(self.default_group)
+        if not names_list and not skip_default_group:
+            names_list.append(self.default_group)
 
         # Add sources from groups
-        groups_filter = [group for group in self.groups if group.name in names]
+        groups_filter = [group for group in self.groups if group.name in names_list]
         sources_filter = [member for group in groups_filter for member in group.members]
 
         # Add independent sources
         sources_filter.extend(
-            [source.name for source in sources if source.name in names]
+            [source.name for source in sources if source.name in names_list]
         )
 
         if not sources_filter:

--- a/gitman/models/config.py
+++ b/gitman/models/config.py
@@ -320,12 +320,12 @@ class Config:
 
         # Add sources from groups
         groups_filter = [group for group in self.groups if group.name in names]
-        sources_filter = [
-            member for group in groups_filter for member in group.members
-        ]
+        sources_filter = [member for group in groups_filter for member in group.members]
 
         # Add independent sources
-        sources_filter.extend([source.name for source in sources if source.name in names])
+        sources_filter.extend(
+            [source.name for source in sources if source.name in names]
+        )
 
         if not sources_filter:
             sources_filter = [source.name for source in sources]

--- a/gitman/models/config.py
+++ b/gitman/models/config.py
@@ -311,33 +311,26 @@ class Config:
 
         return sources + extras
 
-    def _get_default_group(self, names):
-        """Get default group if names is empty."""
-        use_default = not names
-        default_groups = [
-            group
-            for group in self.groups
-            if group.name == self.default_group and use_default
-        ]
-
-        return default_groups
-
     def _get_sources_filter(self, *names, sources, skip_default_group):
         """Get filtered sublist of sources."""
-        sources_filter = None
+        names = list(names)
 
-        groups_filter = [group for group in self.groups if group.name in list(names)]
-        if not skip_default_group:
-            groups_filter += self._get_default_group(list(names))
+        if not names and not skip_default_group:
+            names.append(self.default_group)
 
-        if groups_filter:
-            sources_filter = [
-                members for group in groups_filter for members in group.members
-            ]
-        else:
-            sources_filter = list(names) if names else [s.name for s in sources]
+        # Add sources from groups
+        groups_filter = [group for group in self.groups if group.name in names]
+        sources_filter = [
+            member for group in groups_filter for member in group.members
+        ]
 
-        return sources_filter
+        # Add independent sources
+        sources_filter.extend([source.name for source in sources if source.name in names])
+
+        if not sources_filter:
+            sources_filter = [source.name for source in sources]
+
+        return list(set(sources_filter))
 
 
 def load_config(start=None, *, search=True):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -310,6 +310,64 @@ def describe_install():  # pylint: disable=too-many-statements
             expect(dir_listing).contains('src')
             expect(len(dir_listing) == 1)
 
+    def describe_mixed_names():
+        @pytest.fixture
+        def config_with_group(config):
+            config.datafile.text = strip(
+                """
+                location: deps
+                sources:
+                  - name: gitman_1
+                    type: git
+                    repo: https://github.com/jacebrowning/gitman-demo
+                    sparse_paths:
+                      -
+                    rev: example-branch
+                    link:
+                    scripts:
+                      -
+                  - name: gitman_2
+                    type: git
+                    repo: https://github.com/jacebrowning/gitman-demo
+                    sparse_paths:
+                      -
+                    rev: example-tag
+                    link:
+                    scripts:
+                      -
+                groups:
+                  - name: main_group
+                    members:
+                      - gitman_1
+                  - name: super_group
+                    members:
+                    - gitman_1
+                    - gitman_2
+                """
+            )
+            config.datafile.load()
+
+            return config
+
+        def install_with_group_and_source_is_successful(config_with_group):
+            expect(gitman.install("main_group", "gitman_2", depth=1, force=True)) == True
+            expect(
+                os.path.exists(
+                    os.path.join(config_with_group.location, 'gitman_1')
+                )
+            ) == True
+            expect(
+                os.path.exists(
+                    os.path.join(config_with_group.location, 'gitman_2')
+                )
+            ) == True
+
+        def groups_with_redundant_deps_install_successfully(config_with_group):
+            expect(gitman.install("main_group", "super_group", depth=1, force=True)) == True
+
+        def group_and_redundant_source_install_successfully(config_with_group):
+            expect(gitman.install("main_group", "gitman_1", depth=1, force=True)) == True
+
     def describe_default_group():
         @pytest.fixture
         def config_with_default_group(config):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -350,23 +350,25 @@ def describe_install():  # pylint: disable=too-many-statements
             return config
 
         def install_with_group_and_source_is_successful(config_with_group):
-            expect(gitman.install("main_group", "gitman_2", depth=1, force=True)) == True
             expect(
-                os.path.exists(
-                    os.path.join(config_with_group.location, 'gitman_1')
-                )
+                gitman.install("main_group", "gitman_2", depth=1, force=True)
             ) == True
             expect(
-                os.path.exists(
-                    os.path.join(config_with_group.location, 'gitman_2')
-                )
+                os.path.exists(os.path.join(config_with_group.location, 'gitman_1'))
+            ) == True
+            expect(
+                os.path.exists(os.path.join(config_with_group.location, 'gitman_2'))
             ) == True
 
         def groups_with_redundant_deps_install_successfully(config_with_group):
-            expect(gitman.install("main_group", "super_group", depth=1, force=True)) == True
+            expect(
+                gitman.install("main_group", "super_group", depth=1, force=True)
+            ) == True
 
         def group_and_redundant_source_install_successfully(config_with_group):
-            expect(gitman.install("main_group", "gitman_1", depth=1, force=True)) == True
+            expect(
+                gitman.install("main_group", "gitman_1", depth=1, force=True)
+            ) == True
 
     def describe_default_group():
         @pytest.fixture


### PR DESCRIPTION
Fixes #238. Now you can mix sources and groups on the command line during `gitman install`. For example:

```bash
gitman install my_group my_source
```

The filter logic now does the following:

1. Convert all groups (potentially adding the `default_group`) into lists of sources and combine
2. Add any free standing sources from the command line
3. Remove any redundant entries