### PR TITLE
Add support for multiple symbolic links per repo 

### DIFF
--- a/docs/use-cases/multiple-links.md
+++ b/docs/use-cases/multiple-links.md
@@ -1,0 +1,43 @@
+# Using multiple links
+
+This feature can be used to create as many symbolic links as you need from one repository.
+
+## The syntax
+
+Let's say we have a simple project structure.
+
+|- include
+|- src
+|- docs
+
+```yaml
+location: .gitman 
+
+sources:
+  - repo: <URL of my_dependency repository>
+    name: my_dependency
+    rev: v1.0.3
+    links:
+      - source: include
+        target: vendor/partial_repo
+      - target: vendor/full_repo
+```
+
+This will result in the following symbolic links:
+- `<root>/vendor/partial_repo` -> `<root>/.gitman/my_dependency/include`
+- `<root>/vendor/full_repo` -> `<root>/.gitman/my_dependency`
+
+## Alternative syntax
+
+```yaml
+location: vendor 
+
+sources:
+  - repo: <URL of my_dependency repository>
+      name: my_dependency
+      rev: v1.0.3
+      links:
+        - { source: src, target: partial_repo }
+        - { target: full_repo }
+```
+

--- a/gitman.yml
+++ b/gitman.yml
@@ -1,80 +1,96 @@
 location: demo
 sources:
-  - name: gitman_1
+  - repo: https://github.com/jacebrowning/gitman-demo
+    name: gitman_1
+    rev: example-branch
     type: git
-    repo: https://github.com/jacebrowning/gitman-demo
     sparse_paths:
       -
-    rev: example-branch
     link:
+    links:
+      -
     scripts:
       - cat .noserc
       - make foobar
-  - name: gitman_2
+  - repo: https://github.com/jacebrowning/gitman-demo
+    name: gitman_2
+    rev: example-tag
     type: git
-    repo: https://github.com/jacebrowning/gitman-demo
     sparse_paths:
       -
-    rev: example-tag
     link:
+    links:
+      -
     scripts:
       -
-  - name: gitman_3
+  - repo: https://github.com/jacebrowning/gitman-demo
+    name: gitman_3
+    rev: master@{2015-06-18 11:11:11}
     type: git
-    repo: https://github.com/jacebrowning/gitman-demo
     sparse_paths:
       -
-    rev: master@{2015-06-18 11:11:11}
     link:
+    links:
+      -
     scripts:
       - echo "Hello, World!"
       - pwd
-  - name: gitman_4
+  - repo: https://github.com/jacebrowning/gitman-demo
+    name: gitman_4
+    rev: example-branch-2
     type: git
-    repo: https://github.com/jacebrowning/gitman-demo
     sparse_paths:
       -
-    rev: example-branch-2
     link:
+    links:
+      -
     scripts:
       -
 sources_locked:
-  - name: gitman_1
+  - repo: https://github.com/jacebrowning/gitman-demo
+    name: gitman_1
+    rev: dfd561870c0eb6e814f8f6cd11f8f62f4ae88ea0
     type: git
-    repo: https://github.com/jacebrowning/gitman-demo
     sparse_paths:
       -
-    rev: dfd561870c0eb6e814f8f6cd11f8f62f4ae88ea0
     link:
+    links:
+      -
     scripts:
       - cat .noserc
       - make foobar
-  - name: gitman_2
+  - repo: https://github.com/jacebrowning/gitman-demo
+    name: gitman_2
+    rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
     type: git
-    repo: https://github.com/jacebrowning/gitman-demo
     sparse_paths:
       -
-    rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
     link:
+    links:
+      -
     scripts:
       -
-  - name: gitman_3
+  - repo: https://github.com/jacebrowning/gitman-demo
+    name: gitman_3
+    rev: 2da24fca34af3748e3cab61db81a2ae8b35aec94
     type: git
-    repo: https://github.com/jacebrowning/gitman-demo
     sparse_paths:
       -
-    rev: 2da24fca34af3748e3cab61db81a2ae8b35aec94
     link:
+    links:
+      -
     scripts:
       - echo "Hello, World!"
       - pwd
-  - name: gitman_4
+  - repo: https://github.com/jacebrowning/gitman-demo
+    name: gitman_4
+    rev: f50c1ac8bf27377625b0cc93ea27f8069c7b513a
     type: git
-    repo: https://github.com/jacebrowning/gitman-demo
     sparse_paths:
       -
-    rev: f50c1ac8bf27377625b0cc93ea27f8069c7b513a
     link:
+    links:
+      -
     scripts:
       -
 groups:

--- a/gitman/models/config.py
+++ b/gitman/models/config.py
@@ -112,6 +112,7 @@ class Config:
                 skip_changes=skip_changes,
             )
             source.create_link(self.root, force=force)
+            source.create_links(self.root, force=force)
             common.newline()
             count += 1
 

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -8,6 +8,12 @@ from .. import common, exceptions, git, shell
 
 
 @dataclass
+class Link:
+    source: str = ''
+    target: str = ''
+
+
+@dataclass
 class Source:
     """A dictionary of `git` and `ln` arguments."""
 
@@ -18,6 +24,7 @@ class Source:
     type: str = 'git'
     sparse_paths: List[str] = field(default_factory=list)
     link: Optional[str] = None
+    links: Optional[List[Link]] = field(default_factory=list)
 
     scripts: List[str] = field(default_factory=list)
 
@@ -138,26 +145,25 @@ class Source:
             self.type, self.repo, self.name, fetch=fetch, clean=clean, rev=self.rev
         )
 
+    def create_links(self, root, force=False):
+        """Create links from the source to target directory."""
+        if not self.links:
+            return
+
+        for link in self.links:
+            target = os.path.join(root, os.path.normpath(link.target))
+            relpath = os.path.relpath(os.getcwd(), os.path.dirname(target))
+            source = os.path.join(relpath, os.path.normpath(link.source))
+            create_sym_link(source, target, force)
+
     def create_link(self, root, force=False):
         """Create a link from the target name to the current directory."""
         if not self.link:
             return
 
-        log.info("Creating a symbolic link...")
-
-        target = os.path.join(root, self.link)
+        target = os.path.join(root, os.path.normpath(self.link))
         source = os.path.relpath(os.getcwd(), os.path.dirname(target))
-
-        if os.path.islink(target):
-            os.remove(target)
-        elif os.path.exists(target):
-            if force:
-                shell.rm(target)
-            else:
-                msg = "Preexisting link location at {}".format(target)
-                raise exceptions.UncommittedChanges(msg)
-
-        shell.ln(source, target)
+        create_sym_link(source, target, force)
 
     def run_scripts(self, force=False, show_shell_stdout=False):
         log.info("Running install scripts...")
@@ -271,3 +277,18 @@ class Source:
             path
         )
         return exceptions.InvalidRepository(msg)
+
+
+def create_sym_link(source, target, force):
+    log.info("Creating a symbolic link...")
+
+    if os.path.islink(target):
+        os.remove(target)
+    elif os.path.exists(target):
+        if force:
+            shell.rm(target)
+        else:
+            msg = "Preexisting link location at {}".format(target)
+            raise exceptions.UncommittedChanges(msg)
+
+    shell.ln(source, target)

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -24,7 +24,7 @@ class Source:
     type: str = 'git'
     sparse_paths: List[str] = field(default_factory=list)
     link: Optional[str] = None
-    links: Optional[List[Link]] = field(default_factory=list)
+    links: List[Link] = field(default_factory=list)
 
     scripts: List[str] = field(default_factory=list)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
     - Build System Integration: use-cases/build-integration.md
     - Sparse Checkouts: use-cases/sparse-checkouts.md
     - Default Groups: use-cases/default-groups.md
+    - Using Multiple Links: use-cases/multiple-links.md
   - Extras:
     - Git SVN Bridge: extras/git-svn-bridge.md
     - Bundled Application: extras/bundled-application.md

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,6 +31,8 @@ sources:
     sparse_paths:
       -
     link:
+    links:
+      -
     scripts:
       -
   - repo: https://github.com/jacebrowning/gitman-demo
@@ -40,6 +42,8 @@ sources:
     sparse_paths:
       -
     link:
+    links:
+      -
     scripts:
       -
   - repo: https://github.com/jacebrowning/gitman-demo
@@ -49,6 +53,8 @@ sources:
     sparse_paths:
       -
     link:
+    links:
+      -
     scripts:
       -
 sources_locked:
@@ -98,6 +104,8 @@ def describe_init():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
         sources_locked:
@@ -108,6 +116,8 @@ def describe_init():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
         default_group: ''
@@ -145,6 +155,8 @@ def describe_install():  # pylint: disable=too-many-statements
             type: git
             rev: example-branch
             link:
+            links:
+              -
             scripts:
               -
         sources_locked:
@@ -153,6 +165,8 @@ def describe_install():  # pylint: disable=too-many-statements
             type: git
             rev: example-branch
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -160,6 +174,8 @@ def describe_install():  # pylint: disable=too-many-statements
             type: git
             rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
             link:
+            links:
+              -
             scripts:
               -
         """
@@ -180,6 +196,8 @@ def describe_install():  # pylint: disable=too-many-statements
             type: git
             rev: example-branch
             link:
+            links:
+              -
             scripts:
               -
         sources_locked:
@@ -188,6 +206,8 @@ def describe_install():  # pylint: disable=too-many-statements
             type: git
             rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
             link:
+            links:
+              -
             scripts:
               -
         """
@@ -220,6 +240,8 @@ def describe_install():  # pylint: disable=too-many-statements
                 repo: https://github.com/jacebrowning/gitman-demo
                 rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
                 link: my_link
+                links:
+                  -
                 scripts:
                   -
             """
@@ -263,6 +285,8 @@ def describe_install():  # pylint: disable=too-many-statements
                 repo: https://github.com/jacebrowning/gitman-demo
                 rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
                 link:
+                links:
+                  -
                 scripts:
                   - make foobar
             """
@@ -292,6 +316,8 @@ def describe_install():  # pylint: disable=too-many-statements
                           - src/*
                         rev: ddbe17ef173538d1fda29bd99a14bab3c5d86e78
                         link:
+                        links:
+                          -
                         scripts:
                           -
                     """
@@ -325,6 +351,8 @@ def describe_install():  # pylint: disable=too-many-statements
                       -
                     rev: example-branch
                     link:
+                    links:
+                      -
                     scripts:
                       -
                   - name: gitman_2
@@ -334,6 +362,8 @@ def describe_install():  # pylint: disable=too-many-statements
                       -
                     rev: example-tag
                     link:
+                    links:
+                      -
                     scripts:
                       -
                 groups:
@@ -385,6 +415,8 @@ def describe_install():  # pylint: disable=too-many-statements
               -
             rev: example-branch
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -394,6 +426,8 @@ def describe_install():  # pylint: disable=too-many-statements
               -
             rev: example-tag
             link:
+            links:
+              -
             scripts:
               -
         groups:
@@ -423,6 +457,8 @@ def describe_install():  # pylint: disable=too-many-statements
               -
             rev: example-branch
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -432,6 +468,8 @@ def describe_install():  # pylint: disable=too-many-statements
               -
             rev: example-tag
             link:
+            links:
+              -
             scripts:
               -
         groups:
@@ -560,6 +598,8 @@ def describe_update():
               -
             rev: example-branch
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -569,6 +609,8 @@ def describe_update():
               -
             rev: example-tag
             link:
+            links:
+              -
             scripts:
               -
         sources_locked:
@@ -579,6 +621,8 @@ def describe_update():
               -
             rev: (old revision)
             link:
+            links:
+              -
             scripts:
               -
         groups:
@@ -601,6 +645,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -610,6 +656,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
         sources_locked:
@@ -620,6 +668,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
         groups:
@@ -640,6 +690,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -649,6 +701,8 @@ def describe_update():
               -
             rev: example-tag
             link:
+            links:
+              -
             scripts:
               -
         sources_locked:
@@ -659,6 +713,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
         groups:
@@ -680,6 +736,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -689,6 +747,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
         sources_locked:
@@ -699,6 +759,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
         groups:
@@ -744,6 +806,8 @@ def describe_update():
               -
             rev: example-branch
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -753,6 +817,8 @@ def describe_update():
               -
             rev: example-tag
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -762,6 +828,8 @@ def describe_update():
               -
             rev: example-tag
             link:
+            links:
+              -
             scripts:
               -
         sources_locked:
@@ -772,6 +840,8 @@ def describe_update():
               -
             rev: (old revision)
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -781,6 +851,8 @@ def describe_update():
               -
             rev: (old revision)
             link:
+            links:
+              -
             scripts:
               -
         groups:
@@ -806,6 +878,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -815,6 +889,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -824,6 +900,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
         sources_locked:
@@ -834,6 +912,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -843,6 +923,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
         groups:
@@ -882,6 +964,8 @@ def describe_update():
               -
             rev: example-tag
             link:
+            links:
+              -
             scripts:
               -
         sources_locked:
@@ -892,6 +976,8 @@ def describe_update():
               -
             rev: (old revision)
             link:
+            links:
+              -
             scripts:
               -
         groups:
@@ -913,6 +999,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
         sources_locked:
@@ -923,6 +1011,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
         groups:
@@ -966,6 +1056,8 @@ def describe_update():
               -
             rev: example-tag
             link:
+            links:
+              -
             scripts:
               -
         sources_locked:
@@ -976,6 +1068,8 @@ def describe_update():
               -
             rev: (old revision)
             link:
+            links:
+              -
             scripts:
               -
         groups:
@@ -998,6 +1092,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
         sources_locked:
@@ -1008,6 +1104,8 @@ def describe_update():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
         groups:
@@ -1026,6 +1124,8 @@ def describe_update():
             type: git
             rev: example-branch
             link:
+            links:
+              -
             scripts:
               -
         sources_locked:
@@ -1034,6 +1134,8 @@ def describe_update():
             type: git
             rev: example-branch
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -1041,6 +1143,8 @@ def describe_update():
             type: git
             rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
             link:
+            links:
+              -
             scripts:
               -
         """
@@ -1108,6 +1212,8 @@ def describe_lock():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -1117,6 +1223,8 @@ def describe_lock():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -1126,6 +1234,8 @@ def describe_lock():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
         """
@@ -1148,6 +1258,8 @@ def describe_lock():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -1157,6 +1269,8 @@ def describe_lock():
             sparse_paths:
               -
             link:
+            links:
+              -
             scripts:
               -
         """


### PR DESCRIPTION
Hi

As my collage Johnny mention in issues #247 this is our take on supporting many symbolic links per repo.
A solution for feature #16.
 
I have one problem that I didn't find a solution for.
Running `# make check` yields this error:
gitman/models/source.py:27: error: Incompatible types in assignment (expression has type "List[_T]", variable has type "Optional[List[Link]]")

Apart from the added pytest we tested this on our large projects that now use this feature.