### PR TITLE
Restore Python 3.7 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,6 +3,8 @@ environment:
     RANDOM_SEED: 0
   matrix:
     - PYTHON_MAJOR: 3
+      PYTHON_MINOR: 7
+    - PYTHON_MAJOR: 3
       PYTHON_MINOR: 8
     # TODO: Enable this when Python 3.9 is available in the default images
     # - PYTHON_MAJOR: 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: xenial
 
 language: python
 python:
+  - 3.7
   - 3.8
   - 3.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Updated default arguments to `Source` model for improved library usage.
 - Added support for multiple symbolic `links` per repo. (@gunechristensen)
   - **WARNING**: `link` may be deprecated in a future release.
+- Added support for virtual drives on Windows. (@gunechristensen)
+- Updated scripts installation to be depth-first. (@mrpossoms)
 
 # 2.2 (2020-12-24)
 

--- a/gitman/models/config.py
+++ b/gitman/models/config.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from typing import List, Optional
 
 import log
@@ -341,12 +342,7 @@ class Config:
 
 def load_config(start=None, *, search=True):
     """Load the config for the current project."""
-    if start:
-        start = os.path.abspath(start)
-    else:
-        # Handle if cwd is the root of a virtual drive on windows
-        start = os.path.realpath(os.getcwd())
-        os.chdir(start)
+    start = os.path.abspath(start) if start else _resolve_current_directory()
 
     if search:
         log.debug("Searching for config...")
@@ -373,6 +369,16 @@ def load_config(start=None, *, search=True):
         log.debug("No config found in: %s", start)
 
     return None
+
+
+def _resolve_current_directory():
+    start = os.getcwd()
+    if sys.version_info < (3, 8) and os.name == "nt":
+        log.warn("Python 3.8+ is required to resolve virtual drives on Windows")
+    else:
+        start = os.path.realpath(start)
+        os.chdir(start)
+    return start
 
 
 def _valid_filename(filename):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 
 name = "gitman"
-version = "3.0a2"
+version = "2.3b4"
 description = "A language-agnostic dependency manager using Git."
 
 license = "MIT"
@@ -30,6 +30,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Topic :: Software Development",


### PR DESCRIPTION
Updates https://github.com/jacebrowning/gitman/pull/249 and reverts https://github.com/jacebrowning/gitman/pull/250 to simply warn that virtual drive resolution is not available on Python 3.7.