### PR TITLE
Implement a flat recursive resolver

### DIFF
--- a/gitman/cli.py
+++ b/gitman/cli.py
@@ -336,7 +336,10 @@ def _run_command(function, args, kwargs):
         exit_message = "Run again with '--force' to ignore script errors"
     except exceptions.InvalidConfig as exception:
         _show_error(exception)
-        exit_message = "Check the gitman config of the already imported repositories and the repository that raises the conflict error"
+        exit_message = (
+            "Check the gitman config of the already imported "
+            "repositories and the repository that raises the conflict error"
+        )
     finally:
         if exit_message:
             common.show(exit_message, color='message')

--- a/gitman/cli.py
+++ b/gitman/cli.py
@@ -336,7 +336,7 @@ def _run_command(function, args, kwargs):
         exit_message = "Run again with '--force' to ignore script errors"
     except exceptions.InvalidConfig as exception:
         _show_error(exception)
-        exit_message = "Adapt config and run again"
+        exit_message = "Check the gitman config of the already imported repositories and the repository that raises the conflict error"
     finally:
         if exit_message:
             common.show(exit_message, color='message')

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -37,9 +37,6 @@ class Source:
             self.name = str(self.name)
         self.type = self.type or 'git'
 
-    def _on_post_load(self):
-        pass
-
     def __repr__(self):
         return "<source {}>".format(self)
 

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -37,6 +37,9 @@ class Source:
             self.name = str(self.name)
         self.type = self.type or 'git'
 
+    def _on_post_load(self):
+        pass
+
     def __repr__(self):
         return "<source {}>".format(self)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,6 +23,7 @@ TMP = os.path.join(ROOT, 'tmp')
 
 CONFIG = """
 location: deps
+resolver: recursive-nested
 sources:
   - repo: https://github.com/jacebrowning/gitman-demo
     name: gitman_1
@@ -93,6 +94,7 @@ def describe_init():
         expect(Config().datafile.text) == strip(
             """
         location: gitman_sources
+        resolver: recursive-nested
         sources:
           - repo: https://github.com/githubtraining/hellogitworld
             name: sample_dependency
@@ -144,6 +146,7 @@ def describe_install():  # pylint: disable=too-many-statements
         config.datafile.text = strip(
             """
         location: deps
+        resolver: recursive-nested
         sources:
           - repo: https://github.com/jacebrowning/gitman-demo
             name: gitman_1
@@ -182,6 +185,7 @@ def describe_install():  # pylint: disable=too-many-statements
         config.datafile.text = strip(
             """
         location: deps
+        resolver: recursive-nested
         sources:
           - repo: https://github.com/jacebrowning/gitman-demo
             name: gitman_1
@@ -225,6 +229,7 @@ def describe_install():  # pylint: disable=too-many-statements
             config.datafile.text = strip(
                 """
             location: deps
+            resolver: recursive-nested
             sources:
               - name: gitman_1
                 repo: https://github.com/jacebrowning/gitman-demo
@@ -268,6 +273,7 @@ def describe_install():  # pylint: disable=too-many-statements
             config.datafile.text = strip(
                 """
             location: deps
+            resolver: recursive-nested
             sources:
               - name: gitman_1
                 repo: https://github.com/jacebrowning/gitman-demo
@@ -314,6 +320,7 @@ def describe_install():  # pylint: disable=too-many-statements
             config.datafile.text = strip(
                 """
             location: deps
+            resolver: recursive-nested
             sources:
               - name: gitman_1
                 type: git
@@ -342,6 +349,7 @@ def describe_install():  # pylint: disable=too-many-statements
             config.datafile.text = strip(
                 """
                     location: deps
+                    resolver: recursive-nested
                     sources:
                       - name: gitman_1
                         type: git
@@ -376,6 +384,7 @@ def describe_install():  # pylint: disable=too-many-statements
             config.datafile.text = strip(
                 """
                 location: deps
+                resolver: recursive-nested
                 sources:
                   - name: gitman_1
                     type: git
@@ -438,6 +447,7 @@ def describe_install():  # pylint: disable=too-many-statements
             config.datafile.text = strip(
                 """
         location: deps
+        resolver: recursive-nested
         sources:
           - repo: https://github.com/jacebrowning/gitman-demo
             name: gitman_1
@@ -478,6 +488,7 @@ def describe_install():  # pylint: disable=too-many-statements
             config.datafile.text = strip(
                 """
         location: deps
+        resolver: recursive-nested
         sources:
           - repo: https://github.com/jacebrowning/gitman-demo
             name: gitman_1
@@ -617,6 +628,7 @@ def describe_update():
         config.datafile.text = strip(
             """
         location: deps
+        resolver: recursive-nested
         sources:
           - repo: https://github.com/jacebrowning/gitman-demo
             name: gitman_1
@@ -661,6 +673,7 @@ def describe_update():
         expect(config.datafile.text) == strip(
             """
         location: deps
+        resolver: recursive-nested
         sources:
           - repo: https://github.com/jacebrowning/gitman-demo
             name: gitman_1
@@ -703,6 +716,7 @@ def describe_update():
         config.datafile.text = strip(
             """
         location: deps
+        resolver: recursive-nested
         sources:
           - repo: https://github.com/jacebrowning/gitman-demo
             name: gitman_1
@@ -746,6 +760,7 @@ def describe_update():
         expect(config.datafile.text) == strip(
             """
         location: deps
+        resolver: recursive-nested
         sources:
           - repo: https://github.com/jacebrowning/gitman-demo
             name: gitman_1
@@ -788,6 +803,7 @@ def describe_update():
         config.datafile.text = strip(
             """
         location: deps
+        resolver: recursive-nested
         sources:
           - name: gitman_1
             type: git
@@ -813,6 +829,7 @@ def describe_update():
         config.datafile.text = strip(
             """
         location: deps
+        resolver: recursive-nested
         sources:
           - repo: https://github.com/jacebrowning/gitman-demo
             name: gitman_1
@@ -880,6 +897,7 @@ def describe_update():
         expect(config.datafile.text) == strip(
             """
         location: deps
+        resolver: recursive-nested
         sources:
           - repo: https://github.com/jacebrowning/gitman-demo
             name: gitman_1
@@ -961,6 +979,7 @@ def describe_update():
         config.datafile.text = strip(
             """
         location: deps
+        resolver: recursive-nested
         sources:
           - repo: https://github.com/jacebrowning/gitman-demo
             name: gitman_2
@@ -994,6 +1013,7 @@ def describe_update():
         expect(config.datafile.text) == strip(
             """
         location: deps
+        resolver: recursive-nested
         sources:
           - repo: https://github.com/jacebrowning/gitman-demo
             name: gitman_2
@@ -1049,6 +1069,7 @@ def describe_update():
         config.datafile.text = strip(
             """
         location: deps
+        resolver: recursive-nested
         sources:
           - repo: https://github.com/jacebrowning/gitman-demo
             name: gitman_2
@@ -1083,6 +1104,7 @@ def describe_update():
         expect(config.datafile.text) == strip(
             """
         location: deps
+        resolver: recursive-nested
         sources:
           - repo: https://github.com/jacebrowning/gitman-demo
             name: gitman_2
@@ -1115,6 +1137,7 @@ def describe_update():
         config.datafile.text = strip(
             """
         location: deps
+        resolver: recursive-nested
         sources:
           - repo: https://github.com/jacebrowning/gitman-demo
             name: gitman_1


### PR DESCRIPTION
First try to implement the flat hierarchy resolution strategy as described here #128 

The following resolver-strategies are implemented:
  * recursive-nested: this is default resolver and represents the well known basic gitman recursive nested resolution strategy
  * flat: enforce gitman to ignore nested gitman.yml-files is similar as -d 1 (as described here #235). 
  * recursive-flat: resolves all nested depedencies in a flat manner as described in #128 + #175
  * recursive-flat-nested-links: is basically recursive-flat + creating nested symlinks which means that it looks like recursive-nested for the dependencies but the nested imported dependencies are created as symlinks which are linked to the toplevel location

This work is still in progress a couple of things need to be addressed.
Currently the basic commands update, lock and install work with all resolver but still some tests are broken. There are also some workarounds introduced to avoid that datafiles persist all fields. I hope there is a better solution out there but I didn't find them.

There are also some open question how gitman should deal if the resolver settings are different between the toplevel gitman file and the nested gitman files. Currently the resolver setting of the toplevel gitman file will always override the nested resolver settings.