### PR TITLE
Issue#98 Allow user to specify locking to specific rev

### DIFF
--- a/docs/interfaces/api.md
+++ b/docs/interfaces/api.md
@@ -82,6 +82,14 @@ with optional arguments:
 - `*names`: optional list of dependency source or group names to filter on
 - `root`: specifies the path to the root working tree
 
+with specific revision per source:
+
+- Each item in name may be followed by @git_rev or @git_branch or @git_tag.
+- Example:
+  - `*names = ["<source1>@<sha_rev>", <source2>@<tag>", "<source3>"]`.
+  - Source1 and source2 will be locked to sha_rev and tag if they exist in the repository,
+    source3 will be locked to the currently checked out revision.
+
 ## Uninstall
 
 To delete all dependencies, call:

--- a/docs/interfaces/cli.md
+++ b/docs/interfaces/cli.md
@@ -146,6 +146,16 @@ To restore the exact versions previously checked out, run:
 $ gitman install
 ```
 
+To lock a source to a specific revision
+```
+$gitman lock <name1>@<sha_rev>
+```
+
+To lock a source to latest revision of a specific tag or branch
+```
+$gitman lock <name1>@<git_tag_or_branch>
+```
+
 ## Uninstall
 
 To delete all dependencies, run:

--- a/gitman/commands.py
+++ b/gitman/commands.py
@@ -33,7 +33,9 @@ def init(*, force: bool = False):
             rev="master",
         )
         config.sources.append(source)
-        source = source.lock(rev="ebbbf773431ba07510251bb03f9525c7bab2b13a", verify_rev=False)
+        source = source.lock(
+            rev="ebbbf773431ba07510251bb03f9525c7bab2b13a", verify_rev=False
+        )
         config.sources_locked.append(source)
         config.datafile.save()
 

--- a/gitman/commands.py
+++ b/gitman/commands.py
@@ -33,7 +33,7 @@ def init(*, force: bool = False):
             rev="master",
         )
         config.sources.append(source)
-        source = source.lock(rev="ebbbf773431ba07510251bb03f9525c7bab2b13a")
+        source = source.lock(rev="ebbbf773431ba07510251bb03f9525c7bab2b13a", verify_rev=False)
         config.sources_locked.append(source)
         config.datafile.save()
 

--- a/gitman/git.py
+++ b/gitman/git.py
@@ -261,8 +261,14 @@ def get_branch():
 
 def get_object_rev(object_name):
     """Get the revision associated with the object specified."""
-    log_results = git("log", "-n", "1", object_name)
-    commit_sha = log_results[0].replace("commit ", "")
+    log_results = git("log", "-n", "1", object_name, _show=False, _ignore=True)
+
+    commit_sha = None
+
+    if len(log_results) > 0:
+        if "commit" in log_results[0]:
+            commit_sha = log_results[0].replace("commit ", "")
+
     return commit_sha
 
 

--- a/gitman/git.py
+++ b/gitman/git.py
@@ -261,7 +261,7 @@ def get_branch():
 
 def get_object_rev(object_name):
     """Get the revision associated with the object specified."""
-    log_results = git("log", object_name, "-n", "1")
+    log_results = git("log", "-n", "1", object_name)
     commit_sha = log_results[0].replace("commit ", "")
     return commit_sha
 

--- a/gitman/git.py
+++ b/gitman/git.py
@@ -260,7 +260,7 @@ def get_branch():
 
 
 def get_object_rev(object_name):
-    """Get the revision associated with the object specified"""
+    """Get the revision associated with the object specified."""
     log_results = git("log", object_name, "-n", "1")
     commit_sha = log_results[0].replace("commit ", "")
     return commit_sha

--- a/gitman/git.py
+++ b/gitman/git.py
@@ -258,11 +258,13 @@ def get_branch():
     """Get the current working tree's branch."""
     return git("rev-parse", "--abbrev-ref", "HEAD", _show=False)[0]
 
+
 def get_object_rev(object_name):
     """Get the revision associated with the object specified"""
     log_results = git("log", object_name, "-n", "1")
-    commit_sha = log_results[0].replace('commit ', '')
+    commit_sha = log_results[0].replace("commit ", "")
     return commit_sha
+
 
 def _get_sha_from_rev(rev):
     """Get a rev-parse string's hash."""

--- a/gitman/git.py
+++ b/gitman/git.py
@@ -258,6 +258,11 @@ def get_branch():
     """Get the current working tree's branch."""
     return git("rev-parse", "--abbrev-ref", "HEAD", _show=False)[0]
 
+def get_object_rev(object_name):
+    """Get the revision associated with the object specified"""
+    log_results = git("log", object_name, "-n", "1")
+    commit_sha = log_results[0].replace('commit ', '')
+    return commit_sha
 
 def _get_sha_from_rev(rev):
     """Get a rev-parse string's hash."""

--- a/gitman/models/config.py
+++ b/gitman/models/config.py
@@ -181,7 +181,7 @@ class Config:
         return count
 
     @classmethod
-    def split_name_and_rev(cls, name_rev):
+    def _split_name_and_rev(cls, name_rev):
         true_name = name_rev
         rev = None
         if "@" in name_rev:
@@ -191,19 +191,19 @@ class Config:
         return true_name, rev
 
     @classmethod
-    def remap_names_and_revs(cls, names):
+    def _remap_names_and_revs(cls, names):
 
         name_rev_map = {}
 
         for name in names:
-            base_name, rev = cls.split_name_and_rev(name)
+            base_name, rev = cls._split_name_and_rev(name)
             name_rev_map[base_name] = rev
 
         return name_rev_map.keys(), name_rev_map
 
     def lock_dependencies(self, *names, obey_existing=True, skip_changes=False):
         """Lock down the immediate dependency versions."""
-        sources_to_install, source_to_install_revs = self.remap_names_and_revs([*names])
+        sources_to_install, source_to_install_revs = self._remap_names_and_revs([*names])
         sources = self._get_sources(use_locked=obey_existing).copy()
 
         skip_default = True

--- a/gitman/models/config.py
+++ b/gitman/models/config.py
@@ -203,7 +203,9 @@ class Config:
 
     def lock_dependencies(self, *names, obey_existing=True, skip_changes=False):
         """Lock down the immediate dependency versions."""
-        sources_to_install, source_to_install_revs = self._remap_names_and_revs([*names])
+        sources_to_install, source_to_install_revs = self._remap_names_and_revs(
+            [*names]
+        )
         sources = self._get_sources(use_locked=obey_existing).copy()
 
         skip_default = True

--- a/gitman/models/config.py
+++ b/gitman/models/config.py
@@ -183,10 +183,10 @@ class Config:
     def split_name_and_rev(self, name_rev):
         true_name = name_rev
         rev = None
-        if '@' in name_rev:
-                name_split = name_rev.split('@')
-                true_name = name_split[0]
-                rev = name_split[1]
+        if "@" in name_rev:
+            name_split = name_rev.split("@")
+            true_name = name_split[0]
+            rev = name_split[1]
         return true_name, rev
 
     def remap_names_and_revs(self, names):
@@ -224,7 +224,7 @@ class Config:
 
             rev = None
             if source.name in source_to_install_revs.keys():
-               rev = source_to_install_revs[source.name]
+                rev = source_to_install_revs[source.name]
             source_locked = source.lock(skip_changes=skip_changes, rev=rev)
 
             if source_locked is not None:

--- a/gitman/models/config.py
+++ b/gitman/models/config.py
@@ -180,11 +180,36 @@ class Config:
 
         return count
 
+    def split_name_and_rev(self, name_rev):
+        true_name = name_rev
+        rev = None
+        if '@' in name_rev:
+                name_split = name_rev.split('@')
+                true_name = name_split[0]
+                rev = name_split[1]
+        return true_name, rev
+
+    def remap_names_and_revs(self, names):
+
+        name_rev_map = {}
+
+        for name in names:
+            base_name, rev = self.split_name_and_rev(name)
+            name_rev_map[base_name] = rev
+
+        return name_rev_map.keys(), name_rev_map
+
     def lock_dependencies(self, *names, obey_existing=True, skip_changes=False):
         """Lock down the immediate dependency versions."""
+        sources_to_install, source_to_install_revs = self.remap_names_and_revs([*names])
         sources = self._get_sources(use_locked=obey_existing).copy()
+
+        skip_default = True
+        if len(sources_to_install) == 0:
+            skip_default = False
+
         sources_filter = self._get_sources_filter(
-            *names, sources=sources, skip_default_group=False
+            *sources_to_install, sources=sources, skip_default_group=skip_default
         )
 
         shell.cd(self.location_path)
@@ -197,7 +222,10 @@ class Config:
                 log.info("Skipped dependency: %s", source.name)
                 continue
 
-            source_locked = source.lock(skip_changes=skip_changes)
+            rev = None
+            if source.name in source_to_install_revs.keys():
+               rev = source_to_install_revs[source.name]
+            source_locked = source.lock(skip_changes=skip_changes, rev=rev)
 
             if source_locked is not None:
                 try:

--- a/gitman/models/config.py
+++ b/gitman/models/config.py
@@ -180,7 +180,8 @@ class Config:
 
         return count
 
-    def split_name_and_rev(self, name_rev):
+    @classmethod
+    def split_name_and_rev(cls, name_rev):
         true_name = name_rev
         rev = None
         if "@" in name_rev:
@@ -189,12 +190,13 @@ class Config:
             rev = name_split[1]
         return true_name, rev
 
-    def remap_names_and_revs(self, names):
+    @classmethod
+    def remap_names_and_revs(cls, names):
 
         name_rev_map = {}
 
         for name in names:
-            base_name, rev = self.split_name_and_rev(name)
+            base_name, rev = cls.split_name_and_rev(name)
             name_rev_map[base_name] = rev
 
         return name_rev_map.keys(), name_rev_map

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -238,7 +238,6 @@ class Source:
             if rev == None:
                 log.error(f"No commit found for {rev_tmp} in source {self.name}")
 
-
         if rev == self.DIRTY:
             return None
 

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -233,7 +233,11 @@ class Source:
             )
         elif verify_rev:
             shell.cd(self.name)
+            rev_tmp = rev
             rev = git.get_object_rev(rev)
+            if rev == None:
+                log.error(f"No commit found for {rev_tmp} in source {self.name}")
+
 
         if rev == self.DIRTY:
             return None

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -235,7 +235,7 @@ class Source:
             shell.cd(self.name)
             rev_tmp = rev
             rev = git.get_object_rev(rev)
-            if rev == None:
+            if rev is None:
                 log.error(f"No commit found for {rev_tmp} in source {self.name}")
 
         if rev == self.DIRTY:

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -220,7 +220,7 @@ class Source:
 
         raise self._invalid_repository
 
-    def lock(self, rev=None, allow_dirty=False, skip_changes=False):
+    def lock(self, rev=None, allow_dirty=False, skip_changes=False, verify_rev=True):
         """Create a locked source object.
 
         Return a locked version of the current source if not dirty
@@ -231,10 +231,9 @@ class Source:
             _, _, rev = self.identify(
                 allow_dirty=allow_dirty, allow_missing=False, skip_changes=skip_changes
             )
-        else:
+        elif verify_rev:
             shell.cd(self.name)
             rev = git.get_object_rev(rev)
-            print(rev)
 
         if rev == self.DIRTY:
             return None

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -231,6 +231,10 @@ class Source:
             _, _, rev = self.identify(
                 allow_dirty=allow_dirty, allow_missing=False, skip_changes=skip_changes
             )
+        else:
+            shell.cd(self.name)
+            rev = git.get_object_rev(rev)
+            print(rev)
 
         if rev == self.DIRTY:
             return None

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -237,6 +237,7 @@ class Source:
             rev = git.get_object_rev(rev)
             if rev is None:
                 log.error(f"No commit found for {rev_tmp} in source {self.name}")
+                return None
 
         if rev == self.DIRTY:
             return None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,7 +15,6 @@ from gitman import shell
 from gitman.exceptions import (
     InvalidConfig,
     InvalidRepository,
-    ShellError,
     UncommittedChanges,
 )
 from gitman.models import Config

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,11 +12,7 @@ from freezegun import freeze_time
 
 import gitman
 from gitman import shell
-from gitman.exceptions import (
-    InvalidConfig,
-    InvalidRepository,
-    UncommittedChanges,
-)
+from gitman.exceptions import InvalidConfig, InvalidRepository, UncommittedChanges
 from gitman.models import Config
 
 from .utilities import strip

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1325,8 +1325,7 @@ def describe_lock():
             "63ddfd82d308ddae72d31b61cb8942c898fa05b5"
         )
 
-    def it_should_fail_to_lock_to_invalid_user_specified_reference(config):
+    def it_should_skip_lock_to_invalid_user_specified_reference(config):
         expect(gitman.update(depth=1, lock=False)) == True
 
-        with pytest.raises(ShellError):
-            gitman.lock("gitman_1@deadbeef_ref")
+        expect(gitman.lock("gitman_1@deadbeef_ref")) == False


### PR DESCRIPTION
Implements a mechanism through which the user may lock a specific external to a certain revision.

example:
```bash
gitman lock external1@rev1 group1 external2 # external1 will lock to rev1 other externals will lock to checked out rev
```