### PR TITLE
Copies as alternative to Symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ sources:
   - repo: "https://github.com/google/material-design-icons"
     name: material-design-icons
     rev: master
+    copies:
+      - target: Icons
 
 groups:
   - name: code

--- a/docs/setup/git.md
+++ b/docs/setup/git.md
@@ -52,7 +52,7 @@ The token can also be written to `.netrc` during builds, see the guide for [Trav
 
 ## Symlinks on Windows
 
-If you're using Windows, there are some additional prerequisites to ensure Gitman works seamlessly with symbolic links.
+If you're using Windows, there are some additional prerequisites to ensure Gitman works seamlessly with symbolic links. You could consider using copies instead.
 
 ### Grant Permissions
 

--- a/docs/use-cases/multiple-copies.md
+++ b/docs/use-cases/multiple-copies.md
@@ -1,0 +1,48 @@
+# Using Multiple Copies
+
+This feature can be used to create as many copies as you need from one repository. This can be helpful e.g. on Windows where you need administrator priviledges in order to create a symbolic link.
+
+## The Syntax
+
+Let's say we have a simple project structure:
+
+```text
+|- include
+|- src
+|- docs
+```
+
+with the following `gitman.yml`:
+
+```yaml
+location: .gitman
+
+sources:
+  - repo: <URL of my_dependency repository>
+    name: my_dependency
+    rev: v1.0.3
+    copies:
+      - source: include
+        target: vendor/partial_repo
+      - target: vendor/full_repo
+```
+
+This will result in the following copies:
+
+- `<root>/vendor/partial_repo` -> `<root>/.gitman/my_dependency/include`
+- `<root>/vendor/full_repo` -> `<root>/.gitman/my_dependency`
+
+## Alternative Syntax
+
+```yaml
+location: vendor
+
+sources:
+  - repo: <URL of my_dependency repository>
+      name: my_dependency
+      rev: v1.0.3
+      copies:
+        - { source: src, target: partial_repo }
+        - { target: full_repo }
+```
+

--- a/docs/use-cases/multiple-copies.md
+++ b/docs/use-cases/multiple-copies.md
@@ -29,8 +29,8 @@ sources:
 
 This will result in the following copies:
 
-- `<root>/vendor/partial_repo` -> `<root>/.gitman/my_dependency/include`
-- `<root>/vendor/full_repo` -> `<root>/.gitman/my_dependency`
+- `<root>/.gitman/my_dependency/include` -> `<root>/vendor/partial_repo`
+- `<root>/.gitman/my_dependency` -> `<root>/vendor/full_repo`
 
 ## Alternative Syntax
 

--- a/gitman.yml
+++ b/gitman.yml
@@ -10,6 +10,8 @@ sources:
     links:
       - source: ''
         target: demo/example
+    copies:
+      -
     scripts:
       - cat .noserc
       - make foobar
@@ -22,6 +24,9 @@ sources:
       -
     links:
       -
+    copies:
+      - source: ''
+        target: demo/example
     scripts:
       -
   - repo: https://github.com/jacebrowning/gitman-demo
@@ -32,6 +37,8 @@ sources:
     sparse_paths:
       -
     links:
+      -
+    copies:
       -
     scripts:
       - echo "Hello, World!"
@@ -45,6 +52,8 @@ sources:
       -
     links:
       -
+    copies:
+      -
     scripts:
       -
 sources_locked:
@@ -56,6 +65,8 @@ sources_locked:
     sparse_paths:
       -
     links:
+      -
+    copies:
       -
     scripts:
       - cat .noserc
@@ -69,6 +80,8 @@ sources_locked:
       -
     links:
       -
+    copies:
+      -
     scripts:
       -
   - repo: https://github.com/jacebrowning/gitman-demo
@@ -79,6 +92,8 @@ sources_locked:
     sparse_paths:
       -
     links:
+      -
+    copies:
       -
     scripts:
       - echo "Hello, World!"
@@ -91,6 +106,8 @@ sources_locked:
     sparse_paths:
       -
     links:
+      -
+    copies:
       -
     scripts:
       -

--- a/gitman/models/config.py
+++ b/gitman/models/config.py
@@ -115,6 +115,7 @@ class Config:
             )
             assert self.root, f"Missing root: {self}"
             source.create_links(self.root, force=force)
+            source.create_copies(self.root, force=force)
             common.newline()
             count += 1
 

--- a/gitman/models/config.py
+++ b/gitman/models/config.py
@@ -115,6 +115,7 @@ class Config:
             )
             assert self.root, f"Missing root: {self}"
             source.create_links(self.root, force=force)
+            common.newline()
             source.create_copies(self.root, force=force)
             common.newline()
             count += 1

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -224,7 +224,7 @@ class Source:
         for copy in self.copies:
             target = os.path.join(root, os.path.normpath(copy.target))
             relpath = os.path.relpath(os.getcwd(), os.path.dirname(target))
-            source = os.path.join(relpath, os.path.normpath(copy.source))
+            source = os.path.join(root, os.path.join(relpath, copy.source) if copy.source else relpath)
             create_copy(source, target, force=force)
 
     def run_scripts(self, force: bool = False, show_shell_stdout: bool = False):
@@ -381,6 +381,11 @@ def create_copy(source: str, target: str, *, force: bool):
         os.remove(target)
     elif os.path.exists(target):
         if force:
+            shell.rm(target)
+        elif os.path.isfile(target) and os.path.isdir(source):
+            msg = "Preexisting file location to be replaced by folder at {}".format(target)
+            raise exceptions.UncommittedChanges(msg)
+        elif os.path.isfile(target) and os.path.isfile(source):
             shell.rm(target)
         else:
             msg = "Preexisting target location at {}".format(target)

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -15,6 +15,7 @@ class Link:
     source: str = ""
     target: str = ""
 
+
 @dataclass
 class Copy:
     source: str = ""
@@ -217,14 +218,16 @@ class Source:
             create_sym_link(source, target, force=force)
 
     def create_copies(self, root: str, *, force: bool = False):
-        """Create copies from source to target"""
+        """Create copies from source to target."""
         if not self.copies:
             return
 
         for copy in self.copies:
             target = os.path.join(root, os.path.normpath(copy.target))
             relpath = os.path.relpath(os.getcwd(), os.path.dirname(target))
-            source = os.path.join(root, os.path.join(relpath, copy.source) if copy.source else relpath)
+            source = os.path.join(
+                root, os.path.join(relpath, copy.source) if copy.source else relpath
+            )
             create_copy(source, target, force=force)
 
     def run_scripts(self, force: bool = False, show_shell_stdout: bool = False):
@@ -383,7 +386,9 @@ def create_copy(source: str, target: str, *, force: bool):
         if force:
             shell.rm(target)
         elif os.path.isfile(target) and os.path.isdir(source):
-            msg = "Preexisting file location to be replaced by folder at {}".format(target)
+            msg = "Preexisting file location to be replaced by folder at {}".format(
+                target
+            )
             raise exceptions.UncommittedChanges(msg)
         elif os.path.isfile(target) and os.path.isfile(source):
             shell.rm(target)

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -339,7 +339,7 @@ class Source:
             name=self.name,
             rev=rev,
             links=self.links,
-            copy=self.copy,
+            copies=self.copies,
             scripts=self.scripts,
             sparse_paths=self.sparse_paths,
         )

--- a/gitman/models/source.py
+++ b/gitman/models/source.py
@@ -57,6 +57,10 @@ class Source:
 
     See [using multiple links][using-multiple-links] for more information.
 
+    ### Copies
+
+    See [using multiple copies][using-multiple-copies] for more information.
+
     ### Scripts
 
     Scripts can be used to run post-checkout commands such us build steps. For example:

--- a/gitman/shell.py
+++ b/gitman/shell.py
@@ -1,8 +1,8 @@
 """Utilities to call shell programs."""
 
 import os
-import subprocess
 import shutil
+import subprocess
 
 import log
 

--- a/gitman/shell.py
+++ b/gitman/shell.py
@@ -132,9 +132,8 @@ def cp(source, target):
     dirpath = os.path.dirname(target)
     if not os.path.isdir(dirpath):
         mkdir(dirpath)
-    
     if os.path.isdir(source):
-        shutil.copytree(src=source, dst=target)
+        shutil.copytree(src=source, dst=target, dirs_exist_ok=True)
     else:
         shutil.copy2(src=source, dst=target)
 

--- a/gitman/shell.py
+++ b/gitman/shell.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+import shutil
 
 import log
 
@@ -125,6 +126,17 @@ def ln(source, target):
     if not os.path.isdir(dirpath):
         mkdir(dirpath)
     os.symlink(source, target)
+
+
+def cp(source, target):
+    dirpath = os.path.dirname(target)
+    if not os.path.isdir(dirpath):
+        mkdir(dirpath)
+    
+    if os.path.isdir(source):
+        shutil.copytree(src=source, dst=target)
+    else:
+        shutil.copy2(src=source, dst=target)
 
 
 def rm(path):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
     - Sparse Checkouts: use-cases/sparse-checkouts.md
     - Default Groups: use-cases/default-groups.md
     - Multiple Links: use-cases/multiple-links.md
+    - Multiple Copies: use-cases/multiple-copies.md
   - Extras:
     - Git SVN Bridge: extras/git-svn-bridge.md
     - Bundled Application: extras/bundled-application.md

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -375,20 +375,17 @@ def describe_install():
             expect(os.listdir()).contains("my_copy")
             expect(os.listdir()).contains("libCommon.py")
 
-        def it_should_not_overwrite_files(config_with_copy):
-            os.system("touch my_copy")
+        def it_should_overwrite_files(config_with_copy):
+            os.system("touch libCommon.py")
+            expect(os.listdir()).contains("libCommon.py")
 
-            with pytest.raises(RuntimeError):
-                gitman.install(depth=1)
-
-        def it_should_not_overwrite_non_empty_directories(config_with_copy):
+        def it_should_merge_non_empty_directories(config_with_copy):
             os.system("mkdir my_copy")
             os.system("touch my_copy/my_copy")
 
-            with pytest.raises(RuntimeError):
-                gitman.install(depth=1)
+            expect(os.listdir("my_copy")).contains("my_copy")
 
-        def it_overwrites_files_with_force(config_with_copy):
+        def it_overwrites_folders_with_force(config_with_copy):
             os.system("touch my_copy")
 
             expect(gitman.install(depth=1, force=True)) == True
@@ -407,9 +404,9 @@ def describe_install():
                   -
                 copies:
                   - source: gdm/test
-                    target: gmd_test
-                  - source: gdm/command.py
-                    target: gdmCommand.py
+                    target: gdm_test
+                  - source: gdm/commands.py
+                    target: gdmCommands.py
                 scripts:
                   -
             """
@@ -420,8 +417,8 @@ def describe_install():
 
         def it_should_create_copies(config_with_copies):
             expect(gitman.install(depth=1)) == True
-            expect(os.listdir()).contains("gmd_test")
-            expect(os.listdir()).contains("gdmCommand.py")
+            expect(os.listdir()).contains("gdm_test")
+            expect(os.listdir()).contains("gdmCommands.py")
 
         def it_should_not_overwrite_files_with_folders(config_with_copies):
             os.system("touch gmd_test")
@@ -430,23 +427,26 @@ def describe_install():
                 gitman.install(depth=1)
 
         def it_should_merge_with_non_empty_directories(config_with_copies):
-            os.system("mkdir gmd_test")
-            os.system("touch gmd_test/my_copy")
+            os.system("mkdir gdm_test")
+            os.system("touch gdm_test/my_copy")
 
+            expect(gitman.install(depth=1)) == True
             expect(os.listdir("gmd_test")).contains("my_copy")
 
         def it_should_overwrite_files(config_with_copies):
-            os.system("mkdir gmd_test")
-            os.system("touch gmd_test/test_all.py")
-            os.system("touch gdmCommand.py")
+            os.system("mkdir gdm_test")
+            os.system("touch gdm_test/test_all.py")
+            os.system("touch gdmCommands.py")
 
-            expect(os.listdir("gmd_test")).contains("test_all.py")
+            expect(gitman.install(depth=1)) == True
+            expect(os.listdir("gdm_test")).contains("test_all.py")
             expect(os.listdir()).contains("gdmCommand.py")
             
         def it_overwrites_files_with_force(config_with_copies):
-            os.system("mkdir gmd_test")
-            os.system("touch gmd_test/my_copy")
-            assert "my_copy" not in os.listdir("gmd_test")
+            os.system("mkdir gdm_test")
+            os.system("touch gdm_test/my_copy")
+            expect(gitman.install(depth=1, force=True)) == True
+            expect("my_copy" not in os.listdir("gdm_test")) == True
      
     def describe_scripts():
         @pytest.fixture

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -356,7 +356,7 @@ def describe_install():
                 repo: https://github.com/jacebrowning/gitman-demo
                 rev: 954e166c17d61935037fbd0799fbe0176c29df10
                 links:
-                  - 
+                  -
                 copies:
                   - target: my_copy
                   - source: gdm/common.py
@@ -389,7 +389,7 @@ def describe_install():
             os.system("touch my_copy")
 
             expect(gitman.install(depth=1, force=True)) == True
-    
+
     def describe_multi_copies():
         @pytest.fixture
         def config_with_copies(config):
@@ -422,7 +422,7 @@ def describe_install():
 
         def it_should_not_overwrite_files_with_folders(config_with_copies):
             os.system("touch gdm_test")
-            
+
             with pytest.raises(RuntimeError):
                 gitman.install(depth=1)
 
@@ -441,13 +441,13 @@ def describe_install():
             expect(gitman.install(depth=1)) == True
             expect(os.listdir("gdm_test")).contains("test_all.py")
             expect(os.listdir()).contains("gdmCommands.py")
-            
+
         def it_overwrites_files_with_force(config_with_copies):
             os.system("mkdir gdm_test")
             os.system("touch gdm_test/my_copy")
             expect(gitman.install(depth=1, force=True)) == True
             expect("my_copy" not in os.listdir("gdm_test")) == True
-     
+
     def describe_scripts():
         @pytest.fixture
         def config_with_scripts(config):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,6 +32,8 @@ sources:
       -
     links:
       -
+    copies:
+      -
     scripts:
       -
   - repo: https://github.com/jacebrowning/gitman-demo
@@ -43,6 +45,8 @@ sources:
       -
     links:
       -
+    copies:
+      -
     scripts:
       -
   - repo: https://github.com/jacebrowning/gitman-demo
@@ -53,6 +57,8 @@ sources:
     sparse_paths:
       -
     links:
+      -
+    copies:
       -
     scripts:
       -
@@ -105,6 +111,8 @@ def describe_init():
               -
             links:
               -
+            copies:
+              -
             scripts:
               -
         sources_locked:
@@ -116,6 +124,8 @@ def describe_init():
             sparse_paths:
               -
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -156,6 +166,8 @@ def describe_install():
             rev: main
             links:
               -
+            copies:
+              -
             scripts:
               -
         sources_locked:
@@ -165,6 +177,8 @@ def describe_install():
             rev: example-branch
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -172,6 +186,8 @@ def describe_install():
             type: git
             rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -202,6 +218,8 @@ def describe_install():
             rev: example-branch
             links:
               -
+            copies:
+              -
             scripts:
               -
         sources_locked:
@@ -210,6 +228,8 @@ def describe_install():
             type: git
             rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
             links:
+              -
+            copies:
               -
             scripts:
               -

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -264,6 +264,8 @@ def describe_install():
                 rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
                 links:
                   - target: my_link
+                copies:
+                  -
                 scripts:
                   -
             """
@@ -310,6 +312,8 @@ def describe_install():
                     target: gmd_3
                   - source: gitman_sources/gmd_4
                     target: gmd_4
+                copies:
+                  -
                 scripts:
                   -
             """
@@ -355,6 +359,8 @@ def describe_install():
                 rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
                 links:
                   -
+                copies:
+                  -
                 scripts:
                   - make foobar
             """
@@ -385,6 +391,8 @@ def describe_install():
                           - src/*
                         rev: ddbe17ef173538d1fda29bd99a14bab3c5d86e78
                         links:
+                          -
+                        copies:
                           -
                         scripts:
                           -
@@ -421,6 +429,8 @@ def describe_install():
                     rev: example-branch
                     links:
                       -
+                    copies:
+                      -
                     scripts:
                       -
                   - name: gitman_2
@@ -431,6 +441,8 @@ def describe_install():
                       -
                     rev: example-tag
                     links:
+                      -
+                    copies:
                       -
                     scripts:
                       -
@@ -485,6 +497,8 @@ def describe_install():
             rev: example-branch
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -495,6 +509,8 @@ def describe_install():
               -
             rev: example-tag
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -527,6 +543,8 @@ def describe_install():
             rev: example-branch
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -537,6 +555,8 @@ def describe_install():
               -
             rev: example-tag
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -668,6 +688,8 @@ def describe_update():
             rev: example-branch
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -678,6 +700,8 @@ def describe_update():
               -
             rev: example-tag
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -690,6 +714,8 @@ def describe_update():
               -
             rev: (old revision)
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -715,6 +741,8 @@ def describe_update():
               -
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -725,6 +753,8 @@ def describe_update():
             sparse_paths:
               -
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -737,6 +767,8 @@ def describe_update():
             sparse_paths:
               -
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -760,6 +792,8 @@ def describe_update():
               -
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -770,6 +804,8 @@ def describe_update():
               -
             rev: example-tag
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -782,6 +818,8 @@ def describe_update():
             sparse_paths:
               -
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -806,6 +844,8 @@ def describe_update():
               -
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -816,6 +856,8 @@ def describe_update():
             sparse_paths:
               -
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -828,6 +870,8 @@ def describe_update():
             sparse_paths:
               -
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -878,6 +922,8 @@ def describe_update():
             rev: example-branch
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -889,6 +935,8 @@ def describe_update():
             rev: example-tag
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -899,6 +947,8 @@ def describe_update():
               -
             rev: example-tag
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -912,6 +962,8 @@ def describe_update():
             rev: (old revision)
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -922,6 +974,8 @@ def describe_update():
               -
             rev: (old revision)
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -950,6 +1004,8 @@ def describe_update():
               -
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -961,6 +1017,8 @@ def describe_update():
               -
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -971,6 +1029,8 @@ def describe_update():
             sparse_paths:
               -
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -984,6 +1044,8 @@ def describe_update():
               -
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -994,6 +1056,8 @@ def describe_update():
             sparse_paths:
               -
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -1036,6 +1100,8 @@ def describe_update():
             rev: example-tag
             links:
               -
+            copies:
+              -
             scripts:
               -
         sources_locked:
@@ -1047,6 +1113,8 @@ def describe_update():
               -
             rev: (old revision)
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -1071,6 +1139,8 @@ def describe_update():
               -
             links:
               -
+            copies:
+              -
             scripts:
               -
         sources_locked:
@@ -1082,6 +1152,8 @@ def describe_update():
             sparse_paths:
               -
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -1128,6 +1200,8 @@ def describe_update():
             rev: example-tag
             links:
               -
+            copies:
+              -
             scripts:
               -
         sources_locked:
@@ -1139,6 +1213,8 @@ def describe_update():
               -
             rev: (old revision)
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -1164,6 +1240,8 @@ def describe_update():
               -
             links:
               -
+            copies:
+              -
             scripts:
               -
         sources_locked:
@@ -1175,6 +1253,8 @@ def describe_update():
             sparse_paths:
               -
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -1196,6 +1276,8 @@ def describe_update():
             rev: example-branch
             links:
               -
+            copies:
+              -
             scripts:
               -
         sources_locked:
@@ -1205,6 +1287,8 @@ def describe_update():
             rev: example-branch
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -1212,6 +1296,8 @@ def describe_update():
             type: git
             rev: 7bd138fe7359561a8c2ff9d195dff238794ccc04
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -1282,6 +1368,8 @@ def describe_lock():
               -
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -1293,6 +1381,8 @@ def describe_lock():
               -
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -1303,6 +1393,8 @@ def describe_lock():
             sparse_paths:
               -
             links:
+              -
+            copies:
               -
             scripts:
               -
@@ -1328,6 +1420,8 @@ def describe_lock():
               -
             links:
               -
+            copies:
+              -
             scripts:
               -
           - repo: https://github.com/jacebrowning/gitman-demo
@@ -1338,6 +1432,8 @@ def describe_lock():
             sparse_paths:
               -
             links:
+              -
+            copies:
               -
             scripts:
               -

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -421,7 +421,7 @@ def describe_install():
             expect(os.listdir()).contains("gdmCommands.py")
 
         def it_should_not_overwrite_files_with_folders(config_with_copies):
-            os.system("touch gmd_test")
+            os.system("touch gdm_test")
             
             with pytest.raises(RuntimeError):
                 gitman.install(depth=1)
@@ -431,7 +431,7 @@ def describe_install():
             os.system("touch gdm_test/my_copy")
 
             expect(gitman.install(depth=1)) == True
-            expect(os.listdir("gmd_test")).contains("my_copy")
+            expect(os.listdir("gdm_test")).contains("my_copy")
 
         def it_should_overwrite_files(config_with_copies):
             os.system("mkdir gdm_test")
@@ -440,7 +440,7 @@ def describe_install():
 
             expect(gitman.install(depth=1)) == True
             expect(os.listdir("gdm_test")).contains("test_all.py")
-            expect(os.listdir()).contains("gdmCommand.py")
+            expect(os.listdir()).contains("gdmCommands.py")
             
         def it_overwrites_files_with_force(config_with_copies):
             os.system("mkdir gdm_test")


### PR DESCRIPTION
Symlinking is a great option, especially on Linux. However, on Windows, creating symlinks often requires administrative privileges. To address this, this PR introduces a `copies` option as an alternative. While less performant, it provides a reliable solution. Some users may even prefer this approach, as copied dependencies can be versioned, making it easier to review PRs that include library changes.